### PR TITLE
API Remove getAvailableTranslations and use FluentExtension::Locales for site translations

### DIFF
--- a/docs/en/02_Features/translations.md
+++ b/docs/en/02_Features/translations.md
@@ -3,14 +3,32 @@ summary: Adding translated content to your website.
 
 # Translations
 
-The SilverStripe Translatable module allows you to create and edit multiple pages in various languages. This module also adds the ability for your users to select which language of a page they wish to view.
+The [SilverStripe Fluent](https://github.com/tractorcow/silverstripe-fluent) module allows you to create and edit
+multiple pages in various languages or locales within languages. This module also adds the ability for your users
+to select which language of a page they wish to view.
 
-<div class="notice" markdown='1'>The SilverStripe Translatable module does not translate content automatically, content authors will need to enter the translated content manually for each translated page</div>
+<div class="notice" markdown='1'>The SilverStripe Fluent module does not translate content automatically, content
+authors will need to enter the translated content manually for each translated page</div>
 
-# Setup
+## Setup
 
-The translatable module is already included as part of the CWP basic recipe and the default CWP theme is set up to switch between different languages. To set up a new translation in the CMS visit the [user documentation](https://userhelp.silverstripe.org/en/3.2/optional_features/working_with_translations/about-translatable/).
+The Fluent module is already included as part of the CWP basic recipe and the starter and Wātea CWP themes are
+set up to switch between different languages.
 
-# Technical
+To set up new locales in the CMS, navigate to the "Locales" tab and start creating new locales. You can switch
+between locale contexts using the dropdown menu in the top left corner at any time, and pages edited in the
+selected locale will be saved for that locale.
 
-There are some [caveats](https://github.com/silverstripe/silverstripe-translatable/blob/master/docs/en/index.md#caveats) to the translatable module which are worth reviewing and for advanced implementation details refer to the [usage](https://github.com/silverstripe/silverstripe-translatable/blob/master/docs/en/index.md#usage-1) documentation.
+You can also define inheritance for locales, meaning content that isn't modified at a certain locale can be inherited
+from the "fallback locale".
+
+For more information on using Fluent, please see the [module documentation](https://github.com/tractorcow/silverstripe-fluent/blob/4.0.0-beta2/readme.md).
+
+## Technical
+
+The Fluent module (like other modules like Subsites and Translatable) modifies the SQL queries that SilverStripe
+performs. On occasions this could cause unintended side effects. If you need to perform an action within a certain
+locale, or without a locale, you can pass a callback into `FluentState::singleton()->withState()` to perform a
+function in isolation.
+
+It is also recommended to use the SilverStripe ORM wherever possible and avoid writing manual SQL queries. 

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_2.0.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_2.0.0.md
@@ -22,6 +22,7 @@ For a full overview of the SilverStripe 4 changes, see [the 4.0.0 changelog](htt
   * `$results_per_page`
   * `$classes_to_search`
   * `$search_index_class` removed, use `Injector::inst()->get(\CWP\Search\CwpSearchEngine::class . '.search_index')` instead.
+* `BasePage::getAvailableTranslations` has been removed, use `FluentExtension::Locales` instead (`$Locales` from a template).
 
 For a detailed list of changes, see the full changelog below.
 


### PR DESCRIPTION
This replaces the templatable implementation of the Translatable module with more native functionality from [Fluent](https://github.com/tractorcow/silverstripe-fluent), which is the replacement in CWP 2.0.

## Dependencies

- [ ] Starter theme changes: https://github.com/silverstripe/cwp-starter-theme/pull/15
- [ ] Wātea theme changes: https://github.com/silverstripe/cwp-watea-theme/pull/6

Resolves #16 
  