### PR TITLE
NEW Move CwpStatsReport from cwp/cwp-core into cwp/cwp

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -26,8 +26,4 @@ mappings:
   CleanupGeneratedPdfBuildTask: CWP\CWP\Tasks\CleanupGeneratedPdfBuildTask
   CleanupGeneratedPdfDailyTask: CWP\CWP\Tasks\CleanupGeneratedPdfDailyTask
   PopulateThemeSampleDataTask: CWP\CWP\Tasks\PopulateThemeSampleDataTask
-  WorkflowDefinitionExtensionTest: CWP\CWP\Tests\Extensions\WorkflowDefinitionExtensionTest
-  EventHolderTest: CWP\CWP\Tests\PageTypes\EventHolderTest
-  SitemapPageTest: CWP\CWP\Tests\PageTypes\SitemapPageTest
-  BasePageTest: CWP\CWP\Tests\PageTypes\BasePageTest
-  PopulateThemeSampleDataTaskTest: CWP\CWP\Tests\Tasks\PopulateThemeSampleDataTaskTest
+  CwpStatsReport: CWP\CWP\Report\CwpStatsReport

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_2.0.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_2.0.0.md
@@ -24,6 +24,7 @@ For a full overview of the SilverStripe 4 changes, see [the 4.0.0 changelog](htt
   * `$search_index_class` removed, use `Injector::inst()->get(\CWP\Search\CwpSearchEngine::class . '.search_index')` instead.
 * `BasePage::getAvailableTranslations` has been removed, use `FluentExtension::Locales` instead (`$Locales` from a template).
 * All PDF export functionality from `BasePage` and `BasePageController` has been removed and moved to a new module [cwp/cwp-pdfexport](https://github.com/silverstripe/cwp-pdfexport).
+* `CwpStatsReport` has been moved from the cwp/cwp-core module to cwp/cwp.
 
 For a detailed list of changes, see the full changelog below.
 

--- a/lang/ar.yml
+++ b/lang/ar.yml
@@ -4,7 +4,6 @@ ar:
     FbFieldDesc: 'رابط الفيس بوك(كل شئ بعد "/http://facebook.com", /http://facebook.com <strong>اسم المستخدم<strong/> /http://facebook.com <strong>صفحات/108510539573<strong/>)'
     GaField: 'حساب جوجل التحليلى'
     GaFieldDesc: 'رقم الحساب الذى سيتم استخدامه عبر الموقع بالكامل ( بصيغة <strong>UA-XXXXX-X<strong/>)'
-    LogosIconsTab: الشعارات/الأيقونات
     SocialMediaTab: 'وسائل الإعلام الاجتماعية'
     TwitterField: 'اسم المستخدم الخاص بتويتر'
     TwitterFieldDesc: 'اسم المستخدم الخاص بتويتر (مثلا, /http://twitter.com <strong>اسم المستخدم<strong/>)'
@@ -12,15 +11,12 @@ ar:
     ExternalLinkLabel: 'رابط خارجي'
     InternalLinkLabel: 'رابط داخلى'
     NameLabel: الاسم
-    Note: '<"div class="message good notice>ملاحظة: لو قمت بتحديد رابط خارجى, سيتم تجاهل الرابط الداخلى.<div/>'
-    Note2: '<p> استخدم هذا لتحديد رابط لصفحة إما فى هذا الموقع (رابط داخلى) أو موقع آخر (رابط آخر).<p/>'
-    PLURALNAME: 'روابط سريعة'
+    PLURALNAME: روابط سريعة
     ParentRelationLabel: والد
-    SINGULARNAME: 'رابط سريع'
+    SINGULARNAME: رابط سريع
     SortOrderLabel: 'ترتيب الفرز'
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'أضف جديد'
-    DESCRIPTION: 'صفحة المحتوى العام'
     FeatureButtonText: 'نص الزر'
     FeatureCategoryDropdown: 'أيقونة الفئة'
     FeatureContentFieldLabel: المحتوى
@@ -30,31 +26,21 @@ ar:
   CWP\CWP\PageTypes\BasePage:
     ColumnPageType: 'نوع الصفحة'
     ColumnTitle: عنوان
-    DESCRIPTION: 'صفحة المحتوى العام'
     PLURALNAME: 'الصفحات الأساسية'
     RelatedPages: 'الصفحات المرتبطة'
     SINGULARNAME: 'صفحة رئيسية'
     TagsTabTitle: البطاقات
-    Taxonomy: 'علم التصنيف'
+    Taxonomy: علم التصنيف
     Term: عنصر
     Terms: عناصر
   CWP\CWP\PageTypes\DatedUpdateHolder:
-    DESCRIPTION: 'صفحة المحتوى العام'
-    DateRangeFilterMessage: 'قد تم تصفيتها حسب تاريخ واحد'
-    FilterAppliedMessage: 'قد تم تطبيق الفلتر مع عكس المواعيد.'
     PLURALNAME: 'الصفحات الرئيسية'
     SINGULARNAME: 'حامل التحديث المحدد بموعد'
   CWP\CWP\PageTypes\DatedUpdatePage:
     AbstractDesc: 'الملخص يستخدم لتلخيص صفحات القوائم. هى محددة ب 160 حرف.'
     AbstractTextFieldLabel: ملخص
-    AuthorFieldLabel: مؤلف
-    DESCRIPTION: 'صفحة المحتوى العام'
     DateLabel: تاريخ
-    EndTimeFieldLabel: 'وقت الانتهاء'
-    FeaturedImageFieldLabel: 'صورة مميزة'
-    LocationFieldLabel: موقع
     SINGULARNAME: 'صفحة التحديث المحددة بموعد'
-    StartTimeFieldLabel: 'وقت البدء'
   CWP\CWP\PageTypes\EventHolder:
     DESCRIPTION: 'صفحة حاوية لصفحات الأحداث, توفر تصفية للأحداث و ترقيم الصفحات'
     PLURALNAME: 'الصفحات الرئيسية'

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,9 +1,9 @@
 de:
   CWP\CWP\Extensions\CustomSiteConfig:
     FbField: 'Facebook-Benutzerkennung oder Benutzername'
-    GaField: Google-Analytics-Konto
+    GaField: 'Google-Analytics-Konto'
     SocialMediaTab: 'Soziale Medien'
-    TwitterField: Twitter-Benutzername
+    TwitterField: 'Twitter-Benutzername'
     TwitterFieldDesc: 'Twitter-Benutzername (z.B. http://twitter.com/<strong>Benutzername</strong>)'
   CWP\CWP\Model\Quicklink:
     ExternalLinkLabel: 'Externer Link'
@@ -12,32 +12,23 @@ de:
     PLURALNAME: Schnelllinks
     ParentRelationLabel: Übergeordnet
     SINGULARNAME: Schnelllink
-    SortOrderLabel: Sortierreihenfolge
+    SortOrderLabel: 'Sortierreihenfolge'
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'Neue hinzufügen'
-    DESCRIPTION: 'Allgemeine Inhaltsseite'
-    FeatureButtonText: Schaltflächentext
-    FeatureCategoryDropdown: Kategoriesymbol
+    FeatureButtonText: 'Schaltflächentext'
+    FeatureCategoryDropdown: 'Kategoriesymbol'
     FeatureContentFieldLabel: Inhalt
     Title: Titel
   CWP\CWP\PageTypes\BasePage:
-    ColumnPageType: Seitentyp
+    ColumnPageType: 'Seitentyp'
     ColumnTitle: Titel
-    DESCRIPTION: 'Allgemeine Inhaltsseite'
     PLURALNAME: 'Basis Seiten'
     RelatedPages: 'Abhängige Seiten'
     TagsTabTitle: Schlagwörter
-  CWP\CWP\PageTypes\DatedUpdateHolder:
-    DESCRIPTION: 'Allgemeine Inhaltsseite'
   CWP\CWP\PageTypes\DatedUpdatePage:
-    AuthorFieldLabel: Autor
-    DESCRIPTION: 'Allgemeine Inhaltsseite'
     DateLabel: Datum
-    EndTimeFieldLabel: Endzeit
-    LocationFieldLabel: Ort
-    StartTimeFieldLabel: Startzeit
   CWP\CWP\PageTypes\EventHolder:
     Upcoming: 'Anstehende Ereignisse'
   CWP\CWP\PageTypes\EventPage:
-    PLURALNAME: Ereignisseiten
-    SINGULARNAME: Ereignisseite
+    PLURALNAME: 'Ereignisseiten'
+    SINGULARNAME: 'Ereignisseite'

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -32,3 +32,8 @@ de:
   CWP\CWP\PageTypes\EventPage:
     PLURALNAME: 'Ereignisseiten'
     SINGULARNAME: 'Ereignisseite'
+  CWP\CWP\Report\CwpStatsReport:
+    FileCount: 'Dateianzahl'
+    Name: Name
+    PagesForMainSite: '- auf der Hauptseite'
+    PagesForSubsite: '- auf der Unterseite ''{SubsiteTitle}'''

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -137,3 +137,12 @@ en:
       one: 'A Sitemap Page'
       other: '{count} Sitemap Pages'
     SINGULARNAME: 'Sitemap Page'
+  CWP\CWP\Report\CwpStatsReport:
+    Count: Count
+    Description: 'This report provides various statistics for this site. The "total live page count" is the number that can be compared against the instance size specifications.'
+    FileCount: 'File count'
+    Name: Name
+    PagesForMainSite: '- in the main site'
+    PagesForSubsite: '- in the subsite ''{SubsiteTitle}'''
+    Title: 'Summary statistics'
+    TotalPageCount: 'Total live page count, across all translations and subsites'

--- a/lang/eo.yml
+++ b/lang/eo.yml
@@ -4,41 +4,52 @@ eo:
     FbFieldDesc: 'Facebook-ligilo (ĉio post "http://facebook.com/", ekzemple http://facebook.com/<strong>salutnomo</strong> aŭ http://facebook.com/<strong>paĝoj/108510539573</strong>)'
     GaField: 'Konto poe Google Analytics'
     GaFieldDesc: 'Kontnumero uzota ie en la retejo (en la formato <strong>UA-XXXXX-X</strong>)'
-    LogosIconsTab: Bildsimboloj
     SocialMediaTab: 'Interkona retejo'
     TwitterField: 'Salutnomo por Twitter'
     TwitterFieldDesc: 'Salutnomo por Twitter (eg, http://twitter.com/<strong>salutnomo</strong>)'
   CWP\CWP\Extensions\CwpCommentingExtension:
-    EMAIL_TITLE: Retpoŝto
     WEBSITE_TITLE: 'Via retejo (malnepra)'
     WILL_NOT_BE_PUBLISHED: 'Ne publikiĝos.'
+  CWP\CWP\Extensions\CwpSiteTreeExtension:
+    SHOW_PAGE_UTILITIES: 'Ĉu vidigu paĝajn utilaĵojn?'
+    SHOW_PAGE_UTILITIES_HELP: 'Vi povas malŝalti paĝajn utilaĵojn (presi, kunhavigi, ktp) por ĉi tiu paĝo.'
+  CWP\CWP\Extensions\CwpSiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: 'Ĉi tiu listo vidigas ĉiujn paĝojn kie la dosiero estas enmetita per la faksimila redaktilo.'
+    EDIT: Redakti
   CWP\CWP\Model\Quicklink:
     ExternalLinkLabel: 'Ekstera ligilo'
     InternalLinkLabel: 'Interna ligilo'
     NameLabel: Nomo
-    Note: '<div class="message good notice">Notu: Se vi agordas eksteran ligilon, la interna ligilo ne estos malatentata.</div>'
-    Note2: '<p>Uzu ĉi tion por ligi al paĝo aŭ en ĉi tiu retejo (internaligilo) aŭ en alia retejo (ekstera ligilo).</p>'
-    PLURALNAME: 'Rapidaj ligiloj'
+    PLURALNAME: Rapidaj ligiloj
+    PLURALS:
+      one: 'Unu rapida ligilo'
+      other: '{count} rapidaj ligiloj'
     ParentRelationLabel: Patra
-    SINGULARNAME: 'Rapida ligilo'
+    SINGULARNAME: Rapida ligilo
     SortOrderLabel: 'Ordiga Ordo'
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'Aldoni novan'
     ButtonTextRequired: 'Necesas plenigi butonan tekston'
-    DESCRIPTION: 'Ĝenerala paĝo por enhavo'
     FeatureButtonText: 'Butona teksto'
     FeatureCategoryDropdown: 'Kategoria bildsimbolo'
     FeatureContentFieldLabel: Enhavo
     FeatureLink: 'Paĝo alligota'
+    FeatureOne: 'Prezentita unua'
+    FeatureTwo: 'Prezentita dua'
     LearnMoreLink: 'Paĝo al kiu ligi la butonon "Lerni plu":'
-    PLURALNAME: Hejmpaĝoj
-    SINGULARNAME: Hejmpaĝo
+    PLURALNAME: 'Hejmpaĝoj'
+    PLURALS:
+      one: 'Unu hejmpaĝo'
+      other: '{count} Hejmpaĝoj'
+    SINGULARNAME: 'Hejmpaĝo'
     Title: Titolo
   CWP\CWP\PageTypes\BasePage:
     ColumnPageType: 'Tipo de paĝo'
     ColumnTitle: Titolo
-    DESCRIPTION: 'Ĝenerala paĝo por enhavo'
     PLURALNAME: 'Bazaj paĝoj'
+    PLURALS:
+      one: 'Unu baza paĝo'
+      other: '{count} bazaj paĝoj'
     RelatedPages: 'Rilataj paĝoj'
     SINGULARNAME: 'Baza paĝo'
     TagsTabTitle: Etikedoj
@@ -50,53 +61,74 @@ eo:
     EmptySearch: 'Sercota kampo malplenas, bonvolu enigi informpeton.'
     MetaTitle: 'Serĉi {keywords}'
     NoResult: 'Via informpeto ne liveris rezulton.'
+  CWP\CWP\PageTypes\DateUpdatePage:
+    AuthorFieldLabel: Aŭtoro
+    EndTimeFieldLabel: 'Fina horo'
+    FeaturedImageFieldLabel: 'Prezentita bildo'
+    LocationFieldLabel: Loko
+    StartTimeFieldLabel: 'Komenca horo'
   CWP\CWP\PageTypes\DatedUpdateHolder:
     DATE_EXAMPLE: '(ekzemplo: 2017/12/30)'
-    DESCRIPTION: 'Ĝenerala paĝo por enhavo'
-    DateRangeFilterMessage: 'Filtri laŭ unuopa dato'
     FILTER_BETWEEN: inter
     FILTER_IN: en
-    FILTER_ON: sur
-    FILTER_WITHIN: 'ene de'
+    FILTER_ON: 'sur'
+    FILTER_WITHIN: ene de
     FROM_DATE: 'Eka dato'
-    FilterAppliedMessage: 'Aplikis filtron laŭ la inversigitaj datoj'
     PLURALNAME: 'Ĝisdatigaj datujoj'
+    PLURALS:
+      one: 'Unu ĝisdatiga datujo'
+      other: '{count} ĝisdatigaj datujoj'
     SINGULARNAME: 'Ĝisdatiga datujo'
     TO_DATE: 'Ĝisa dato'
   CWP\CWP\PageTypes\DatedUpdatePage:
     AbstractDesc: 'La resumo uzatas kiel resumo en la listaj paĝoj. Ĝi havas la limon 160 signoj'
     AbstractTextFieldLabel: Resumo
-    AuthorFieldLabel: Aŭtoro
-    DESCRIPTION: 'Ĝenerala paĝo por enhavo'
     DateLabel: Dato
-    EndTimeFieldLabel: 'Fina horo'
-    FeaturedImageFieldLabel: 'Prezentita bildo'
-    LocationFieldLabel: Loko
     PLURALNAME: 'Ĝisdatigaj datujoj'
+    PLURALS:
+      one: 'Unu ĝisdatiga datujo'
+      other: '{count} ĝisdatigaj datujoj'
     SINGULARNAME: 'Ĝisdatiga datujo'
-    StartTimeFieldLabel: 'Komenca horo'
   CWP\CWP\PageTypes\EventHolder:
     DESCRIPTION: 'Paĝo por enhavi eventpaĝojn, donas eventfiltradon kaj paĝonumeradon'
-    PLURALNAME: Eventujoj
-    SINGULARNAME: Eventujo
+    PLURALNAME: 'Eventujoj'
+    PLURALS:
+      one: 'Unu eventujo'
+      other: '{count} eventujoj'
+    SINGULARNAME: 'Eventujo'
     Upcoming: 'Futuraj eventoj'
   CWP\CWP\PageTypes\EventPage:
     DESCRIPTION: 'Priskribas eventon okazontan je specifa dato.'
-    PLURALNAME: Eventopaĝoj
-    SINGULARNAME: Eventopaĝo
+    PLURALNAME: 'Eventopaĝoj'
+    PLURALS:
+      one: 'Unu eventa paĝo'
+      other: '{count} eventaj paĝoj'
+    SINGULARNAME: 'Eventopaĝo'
   CWP\CWP\PageTypes\FooterHolder:
     DESCRIPTION: 'Paĝo por enhavi kaj vidigi ĉiujn paĝidojn kiel ligilojn en la paĝopiedo'
     PLURALNAME: 'Paĝopieda tenanto'
+    PLURALS:
+      one: 'Unu paĝopieda tenanto'
+      other: '{count} paĝopiedaj tenantoj'
     SINGULARNAME: 'Paĝopieda tenanto'
   CWP\CWP\PageTypes\NewsHolder:
     DESCRIPTION: 'Paĝo por enhavi Novaĵpaĝojn, donas filtradon de novaĵoj kaj paĝonumeradon'
-    PLURALNAME: Novaĵujoj
-    SINGULARNAME: Novaĵujo
+    PLURALNAME: 'Novaĵujoj'
+    PLURALS:
+      one: 'Unu novaĵujo'
+      other: '{count} novaĵujoj'
+    SINGULARNAME: 'Novaĵujo'
   CWP\CWP\PageTypes\NewsPage:
     DESCRIPTION: 'Priskribas novaĵeron'
-    PLURALNAME: Novaĵopaĝoj
-    SINGULARNAME: Novaĵopaĝo
+    PLURALNAME: 'Novaĵopaĝoj'
+    PLURALS:
+      one: 'Unu novaĵopaĝo'
+      other: '{count} novaĵopaĝoj'
+    SINGULARNAME: 'Novaĵopaĝo'
   CWP\CWP\PageTypes\SitemapPage:
     DESCRIPTION: 'Listigas ĉiujn paĝojn en la retejo'
     PLURALNAME: 'Paĝo de paĝarmapo'
+    PLURALS:
+      one: 'Unu paĝarmapa paĝo'
+      other: '{count} paĝarmapaj paĝoj'
     SINGULARNAME: 'Paĝo de paĝarmapo'

--- a/lang/eo.yml
+++ b/lang/eo.yml
@@ -132,3 +132,12 @@ eo:
       one: 'Unu paĝarmapa paĝo'
       other: '{count} paĝarmapaj paĝoj'
     SINGULARNAME: 'Paĝo de paĝarmapo'
+  CWP\CWP\Report\CwpStatsReport:
+    Count: Nombro
+    Description: 'Ĉi tiu raporto donas diversajn statistikojn por la retejo. La "nombro da publikaj paĝoj" estas la nombro komparebla kun la agorda grando de ekzemplo.'
+    FileCount: 'Nombro da dosieroj'
+    Name: Nomo
+    PagesForMainSite: '- en la ĉefa retejo'
+    PagesForSubsite: '- en la subretejo ''{SubsiteTitle}'''
+    Title: 'Resumaj statistikoj'
+    TotalPageCount: 'Totala nombro da paĝoj, en ĉiuj tradukoj kaj subretejoj'

--- a/lang/es.yml
+++ b/lang/es.yml
@@ -4,7 +4,6 @@ es:
     FbFieldDesc: 'Enlace de Facebook (todo lo que sigue a "http://facebook.com/", por ejemplo, http://facebook.com/<strong>nombre de usuario</strong> o http://facebook.com/<strong>pages/108510539573</strong>)'
     GaField: 'Cuenta de Google Analytics'
     GaFieldDesc: 'Número de cuenta a usarse en todo el sitio (en el formato <strong>UA-XXXXX-X</strong>)'
-    LogosIconsTab: Logos/iconos
     SocialMediaTab: 'Medios sociales'
     TwitterField: 'Nombre de usuario de Twitter'
     TwitterFieldDesc: 'Nombre de usuario de Twitter (por ejemplo, http://twitter.com/<strong>nombre de usuario</strong>)'
@@ -12,13 +11,10 @@ es:
     ExternalLinkLabel: 'Enlace externo'
     InternalLinkLabel: 'Enlace interno'
     NameLabel: Nombre
-    Note: '<div class="message good notice">Nota: Si Ud especifica un Enlace Externo, se ignorará al Enlace Interno.</div>'
-    Note2: '<p>Use esto para especificar un enlace a una página sea tanto en este sitio (enlace interno) como de otro sitio (enlace externo).</p>'
     ParentRelationLabel: Padre
     SortOrderLabel: 'Orden de clasificación'
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'Agregar nuevo'
-    DESCRIPTION: 'Página de contenido genérico'
     FeatureButtonText: 'Texto del botón'
     FeatureCategoryDropdown: 'Icono de categoría'
     FeatureContentFieldLabel: Contenido
@@ -28,7 +24,6 @@ es:
   CWP\CWP\PageTypes\BasePage:
     ColumnPageType: 'Tipo de página'
     ColumnTitle: Título
-    DESCRIPTION: 'Página de contenido genérico'
     PLURALNAME: 'Páginas base'
     RelatedPages: 'Páginas relacionadas'
     SINGULARNAME: 'Página base'
@@ -37,17 +32,8 @@ es:
     Term: Término
     Terms: Términos
     TermsDescription: 'Hacer clic para buscar términos adicionales'
-  CWP\CWP\PageTypes\DatedUpdateHolder:
-    DESCRIPTION: 'Página de contenido genérico'
-    DateRangeFilterMessage: 'Filtrado por una sola fecha.'
-    FilterAppliedMessage: 'El filtro se aplicó con las fechas invertidas.'
   CWP\CWP\PageTypes\DatedUpdatePage:
-    AuthorFieldLabel: Autor
-    DESCRIPTION: 'Página de contenido genérico'
     DateLabel: Fecha
-    EndTimeFieldLabel: 'Hora de fin'
-    LocationFieldLabel: Ubicación
-    StartTimeFieldLabel: 'Hora de inicio'
   CWP\CWP\PageTypes\EventHolder:
     DESCRIPTION: 'La página contenedora para páginas de eventos, proporciona filtrado de eventos y paginación'
     Upcoming: 'Próximos eventos'
@@ -65,5 +51,3 @@ es:
     DESCRIPTION: 'Lista todas las páginas del sitio'
     PLURALNAME: 'Páginas de mapa del sitio'
     SINGULARNAME: 'Página de mapa del sitio'
-  CWP\CWP\Search\CwpSearchPage:
-    PLURALNAME: 'Página base'

--- a/lang/fi.yml
+++ b/lang/fi.yml
@@ -57,3 +57,12 @@ fi:
     DESCRIPTION: 'Listaa sivuston kaikki sivut'
     PLURALNAME: 'Sivukarttasivut'
     SINGULARNAME: 'Sivukarttasivu'
+  CWP\CWP\Report\CwpStatsReport:
+    Count: Lukumäärä
+    Description: 'Tämä raportti sisältää tilastotietoa sivustosta. "Julkaistujen sivujen määrää" voidaan verrata osion kokoon.'
+    FileCount: 'Tiedostojen määrä'
+    Name: Nimi
+    PagesForMainSite: '- pääsivustolla'
+    PagesForSubsite: '- alasivustolla ''{SubsiteTitle}'''
+    Title: 'Yhteenvetotilasto'
+    TotalPageCount: 'Julkaistujen sivujen määrä, kaikki käännetyt ja alasivut huomioiden'

--- a/lang/fi.yml
+++ b/lang/fi.yml
@@ -4,9 +4,8 @@ fi:
     FbFieldDesc: 'Facebook-linkki (osan "http://facebook.com/" jälkeinen osa, esim. http://facebook.com/<strong>käyttäjänimi</strong> tai http://facebook.com/<strong>pages/108510539573</strong>)'
     GaField: 'Google Analytics -tili'
     GaFieldDesc: 'Tilinumero käytettäväksi läpi sivuston (formaatissa <strong>UA-XXXXX-X</strong>)'
-    LogosIconsTab: Logot/ikonit
     SocialMediaTab: 'Sosiaalinen media'
-    TwitterField: Twitter-käyttäjänimi
+    TwitterField: 'Twitter-käyttäjänimi'
     TwitterFieldDesc: 'Twitter-käyttäjänimi (esim, http://twitter.com/<strong>käyttäjänimi</strong>)'
   CWP\CWP\Model\Quicklink:
     ExternalLinkLabel: 'Ulkoinen linkki'
@@ -15,57 +14,46 @@ fi:
     PLURALNAME: Pikalinkit
     ParentRelationLabel: Isäntä
     SINGULARNAME: Pikalinkki
-    SortOrderLabel: Järjestys
+    SortOrderLabel: 'Järjestys'
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'Lisää uusi'
     ButtonTextRequired: 'Painiketeksti pitää syöttää'
-    DESCRIPTION: 'Yleinen sisältösivu'
     FeatureButtonText: 'Nappulan teksti'
-    FeatureCategoryDropdown: Kategoriaikoni
+    FeatureCategoryDropdown: 'Kategoriaikoni'
     FeatureContentFieldLabel: Sisältö
     FeatureLink: 'Sivu, johon linkitetään'
     LearnMoreLink: 'Sivu jolle painike linkitetään:'
-    PLURALNAME: Kotisivut
-    SINGULARNAME: Kotisivu
+    PLURALNAME: 'Kotisivut'
+    SINGULARNAME: 'Kotisivu'
     Title: Otsikko
   CWP\CWP\PageTypes\BasePage:
-    ColumnPageType: Sivutyyppi
+    ColumnPageType: 'Sivutyyppi'
     ColumnTitle: Otsikko
-    DESCRIPTION: 'Yleinen sisältösivu'
-    PLURALNAME: Pohjasivut
+    PLURALNAME: 'Pohjasivut'
     RelatedPages: 'Liittyvät sivut'
-    SINGULARNAME: Pohjasivu
+    SINGULARNAME: 'Pohjasivu'
     TagsTabTitle: Avainsanat
     Taxonomy: Taksonomia
     Term: Termi
     Terms: Termit
     TermsDescription: 'Klikkaa etsiäksesi muita termejä'
-  CWP\CWP\PageTypes\DatedUpdateHolder:
-    DESCRIPTION: 'Yleinen sisältösivu'
-    DateRangeFilterMessage: 'Suodatettu yhden päivämäärän mukaan.'
   CWP\CWP\PageTypes\DatedUpdatePage:
     AbstractTextFieldLabel: Tiivistelmä
-    AuthorFieldLabel: Kirjoittaja
-    DESCRIPTION: 'Yleinen sisältösivu'
     DateLabel: Päivämäärä
-    EndTimeFieldLabel: Päättyen
-    FeaturedImageFieldLabel: Kuvanosto
-    LocationFieldLabel: Paikka
-    StartTimeFieldLabel: Alkaen
   CWP\CWP\PageTypes\EventHolder:
     Upcoming: 'Tulevat tapahtumat'
   CWP\CWP\PageTypes\EventPage:
-    PLURALNAME: Tapahtumasivut
-    SINGULARNAME: Tapahtumasivu
+    PLURALNAME: 'Tapahtumasivut'
+    SINGULARNAME: 'Tapahtumasivu'
   CWP\CWP\PageTypes\FooterHolder:
     SINGULARNAME: 'Alaindeksin koonti'
   CWP\CWP\PageTypes\NewsHolder:
     PLURALNAME: 'Uutisten koontisivu'
     SINGULARNAME: 'Uutisten koontisivu'
   CWP\CWP\PageTypes\NewsPage:
-    PLURALNAME: Uutissivut
-    SINGULARNAME: Uutissivu
+    PLURALNAME: 'Uutissivut'
+    SINGULARNAME: 'Uutissivu'
   CWP\CWP\PageTypes\SitemapPage:
     DESCRIPTION: 'Listaa sivuston kaikki sivut'
-    PLURALNAME: Sivukarttasivut
-    SINGULARNAME: Sivukarttasivu
+    PLURALNAME: 'Sivukarttasivut'
+    SINGULARNAME: 'Sivukarttasivu'

--- a/lang/id.yml
+++ b/lang/id.yml
@@ -4,14 +4,12 @@ id:
     FbFieldDesc: 'Tautan Facebook (semua bagian tautan setelah "http://facebook.com/", misal http://facebook.com/<strong>nama_pengguna</strong> atau http://facebook.com/<strong>pages/108510539573</strong>)'
     GaField: 'Akun Google Analytics'
     GaFieldDesc: 'Angka akun untuk digunakan di seluruh bagian situs (dalam format <strong>UA-XXXXX-X</strong>)'
-    LogosIconsTab: Logo/Ikon
     SocialMediaTab: 'Media Sosial'
     TwitterField: 'Nama Pengguna Twitter '
   CWP\CWP\Model\Quicklink:
     NameLabel: Nama
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'Tambah baru'
-    DESCRIPTION: 'Laman konten biasa'
     FeatureButtonText: 'Tombol teks'
     FeatureCategoryDropdown: 'Ikon kategori'
     FeatureContentFieldLabel: Konten
@@ -23,7 +21,6 @@ id:
   CWP\CWP\PageTypes\BasePage:
     ColumnPageType: 'Jenis Laman'
     ColumnTitle: Judul
-    DESCRIPTION: 'Laman konten biasa'
     PLURALNAME: 'Laman Dasar'
     RelatedPages: 'Laman berkaitan'
     SINGULARNAME: 'Laman Dasar'
@@ -34,11 +31,7 @@ id:
     TermsDescription: 'Klik untuk mencari term tambahan'
   CWP\CWP\PageTypes\DatedUpdatePage:
     AbstractTextFieldLabel: Abstrak
-    AuthorFieldLabel: Pengarang
     DateLabel: Tanggal
-    EndTimeFieldLabel: 'Tanggal Akhir'
-    LocationFieldLabel: Lokasi
-    StartTimeFieldLabel: 'Waktu Mulai'
   CWP\CWP\PageTypes\SitemapPage:
     DESCRIPTION: 'Tampilkan semua laman pada situs'
     PLURALNAME: 'Laman Peta Situs'

--- a/lang/id.yml
+++ b/lang/id.yml
@@ -36,3 +36,12 @@ id:
     DESCRIPTION: 'Tampilkan semua laman pada situs'
     PLURALNAME: 'Laman Peta Situs'
     SINGULARNAME: 'Laman Peta Situs'
+  CWP\CWP\Report\CwpStatsReport:
+    Count: Hitung
+    Description: 'Laporan ini menyediakan berbagai statistik situs. "jumlah hitungan laman live" adalah angka yang bisa dibandingkan dengan spesifikasi ukuran instans.'
+    FileCount: 'Hitung Berkas'
+    Name: Nama
+    PagesForMainSite: '- pada situs utama'
+    PagesForSubsite: '- pada sub-situs ''{SubsiteTitle}'''
+    Title: 'Ringkasan statistik'
+    TotalPageCount: 'Jumlah hitungan laman live, mencakup semua terjemahan dan sub-situs'

--- a/lang/mi.yml
+++ b/lang/mi.yml
@@ -10,46 +10,33 @@ mi:
     ExternalLinkLabel: 'Hono ā-Waho'
     InternalLinkLabel: 'Hono ā-Roto'
     NameLabel: Ingoa
-    Note: '<div class="message good notice">Tuhipoka:  Mēnā ka whakarite koe i tētahi Hono ā-Waho, ka waiho te Hono ā-Roto.</div>'
-    Note2: '<p>Whakamahia tēnei hei whakarite i tētahi hono ki tētahi whārangi i tēnei pae (Hono ā-Roto), i tētahi atu pae (Hono ā-Waho).</p>'
-    PLURALNAME: 'Ngā Honotere'
+    PLURALNAME: Ngā Honotere
     ParentRelationLabel: Matua
     SINGULARNAME: Honotere
     SortOrderLabel: 'Raupapa Kōmaka'
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'Tāpiri Hou'
-    DESCRIPTION: 'Whārangi ihirangi whānui'
     FeatureButtonText: 'Kuputuhi pātene'
     FeatureCategoryDropdown: 'Ata kāwai'
-    FeatureContentFieldLabel: 'Ngā ihirangi'
+    FeatureContentFieldLabel: Ngā ihirangi
     FeatureLink: 'Whārangi hono ki'
     LearnMoreLink: 'Whārangi hono i te pātene "Ako Anō" ki:'
     Title: Taitara
   CWP\CWP\PageTypes\BasePage:
-    DESCRIPTION: 'Whārangi ihirangi whānui'
     PLURALNAME: 'Ngā Whārangi Taketake'
     RelatedPages: 'Ngā whārangi pāhono'
     SINGULARNAME: 'Whārangi Taketake'
-    Taxonomy: 'Pūnaha Whakarōpū'
+    Taxonomy: Pūnaha Whakarōpū
     Term: Ture
-    Terms: 'Ngā Ture'
+    Terms: Ngā Ture
   CWP\CWP\PageTypes\DatedUpdateHolder:
-    DESCRIPTION: 'Whārangi ihirangi whānui'
-    DateRangeFilterMessage: 'I tātaritia mā te rā kotahi.'
-    FilterAppliedMessage: 'Kua hoatu te tātari engari kua kōarotia ngā rā.'
     PLURALNAME: 'Ngā Whārangi Taketake'
     SINGULARNAME: 'Pūpupuri Whakahōu Whai Rā'
   CWP\CWP\PageTypes\DatedUpdatePage:
     AbstractDesc: 'Ka whakamahia te tangohanga hei whakarāpopotonga i ngā whārangi whakarārangi. Ka whakatikia ki te 160 pūāhua.'
     AbstractTextFieldLabel: Tangohanga
-    AuthorFieldLabel: Kaituhi
-    DESCRIPTION: 'Whārangi ihirangi ahuwhānui'
     DateLabel: Rā
-    EndTimeFieldLabel: 'Wā Mutu'
-    FeaturedImageFieldLabel: 'Atahanga Kua Whakaaturia'
-    LocationFieldLabel: Tauwāhi
     SINGULARNAME: 'Whārangi Whakahōu Whai Rā'
-    StartTimeFieldLabel: 'Wā Tīmata'
   CWP\CWP\PageTypes\EventHolder:
     DESCRIPTION: 'Whārangi ipu mō ngā Whārangi Takahanga, ka whakarato tātaringa takahanga me te whakawhārangitanga'
     PLURALNAME: 'Ngā Whārangi Taketake'

--- a/lang/ru.yml
+++ b/lang/ru.yml
@@ -4,12 +4,10 @@ ru:
     FbFieldDesc: 'Ссылка на Фейсбук (всё, что после "https://www.facebook.com/", например https://www.facebook.com/<strong>ДжонГалт</strong> или https://www.facebook.com/<strong>pages/108510539573</strong>)'
     GaField: 'Аккаунт Google Analytics'
     GaFieldDesc: 'Номер аккаунта для использования на сайте (в формате <strong>UA-XXXXX-X</strong>)'
-    LogosIconsTab: Логотипы/Иконки
     SocialMediaTab: 'Социальные сети'
     TwitterField: 'Имя пользователя в Twitter'
     TwitterFieldDesc: 'Имя пользователя в Twitter (например, https://twitter.com/<strong>ДжонГалт</strong>)'
   CWP\CWP\Extensions\CwpCommentingExtension:
-    EMAIL_TITLE: Email
     WEBSITE_TITLE: 'Ваш сайт (опционально)'
     WILL_NOT_BE_PUBLISHED: 'Не будет опубликовано.'
   CWP\CWP\Extensions\CwpSiteTreeExtension:
@@ -23,7 +21,6 @@ ru:
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'Добавить новую'
     ButtonTextRequired: 'Название кнопок должно быть указано'
-    DESCRIPTION: 'Обычная страница'
     FeatureButtonText: 'Название кнопки'
     FeatureCategoryDropdown: 'Иконка категории'
     FeatureContentFieldLabel: Содержимое
@@ -35,7 +32,6 @@ ru:
   CWP\CWP\PageTypes\BasePage:
     ColumnPageType: 'Тип страницы'
     ColumnTitle: Заголовок
-    DESCRIPTION: 'Обычная страница'
     PLURALNAME: 'Базовые страницы'
     RelatedPages: 'Зависимые страницы'
     SINGULARNAME: 'Основная страница'
@@ -50,14 +46,10 @@ ru:
     NoResult: 'По Вашему запросу ничего не найдено.'
   CWP\CWP\PageTypes\DatedUpdateHolder:
     DATE_EXAMPLE: '(например: 2017/12/30)'
-    DESCRIPTION: 'Обычная страница'
-    DateRangeFilterMessage: 'Ограничено одной датой'
     FILTER_BETWEEN: между
     FILTER_IN: в
-    FILTER_ON: на
+    FILTER_ON: 'на'
     FILTER_WITHIN: в
-  CWP\CWP\PageTypes\DatedUpdatePage:
-    DESCRIPTION: 'Обычная страница'
   CWP\CWP\PageTypes\NewsHolder:
     PLURALNAME: 'Контейнеры новостей'
     SINGULARNAME: 'Контейнер новости'

--- a/lang/ru.yml
+++ b/lang/ru.yml
@@ -61,3 +61,11 @@ ru:
     DESCRIPTION: 'Отобразить все страницы этого сайта'
     PLURALNAME: 'Страницы карты сайта'
     SINGULARNAME: 'Страница карты сайта'
+  CWP\CWP\Report\CwpStatsReport:
+    Count: Количество
+    FileCount: 'Количество файлов'
+    Name: Название
+    PagesForMainSite: '- на главном сайте'
+    PagesForSubsite: '- на подсайте ''{SubsiteTitle}'''
+    Title: 'Общая статистика'
+    TotalPageCount: 'Общее количество страниц - на всех подсайтах и языках'

--- a/lang/sv.yml
+++ b/lang/sv.yml
@@ -2,28 +2,20 @@ sv:
   CWP\CWP\Extensions\CustomSiteConfig:
     FbField: 'Facebook UID eller användarnamn'
     GaField: 'Google Analytics-konto'
-    LogosIconsTab: Logotyper/ikoner
   CWP\CWP\PageTypes\BaseHomePage:
     AddNewButton: 'Skapa ny'
-    DESCRIPTION: 'Generisk innehållssida'
-    FeatureButtonText: Knapp-text
-    FeatureCategoryDropdown: Kategori-ikon
+    FeatureButtonText: 'Knapp-text'
+    FeatureCategoryDropdown: 'Kategori-ikon'
     FeatureContentFieldLabel: Innehåll
     FeatureLink: 'Sida att länka till'
     LearnMoreLink: 'Sida att länka "Läs mer"-knappen till'
-    PLURALNAME: Hem-sidor
-    SINGULARNAME: Hem
+    PLURALNAME: 'Hem-sidor'
+    SINGULARNAME: 'Hem'
     Title: Titel
   CWP\CWP\PageTypes\BasePage:
-    ColumnPageType: Sidtyp
+    ColumnPageType: 'Sidtyp'
     ColumnTitle: Titel
-    DESCRIPTION: 'Generisk innehållssida'
     PLURALNAME: 'Bas sidor'
     RelatedPages: 'Relaterade sidor'
     TagsTabTitle: Taggar
     Taxonomy: Taxonomi
-  CWP\CWP\PageTypes\DatedUpdateHolder:
-    DESCRIPTION: 'Generisk innehållssida'
-  CWP\CWP\PageTypes\DatedUpdatePage:
-    AuthorFieldLabel: Författare
-    DESCRIPTION: 'Generisk innehållssida'

--- a/lang/zh.yml
+++ b/lang/zh.yml
@@ -4,76 +4,62 @@ zh:
     FbFieldDesc: 'Facebook 链接（ "http://facebook.com/" 之后的所有内容，例如 http://facebook.com/<strong>username</strong> 或 http://facebook.com/<strong>pages/108510539573</strong>）'
     GaField: 'Google Analytics 帐户'
     GaFieldDesc: '账户号码在整个站点通用（格式 <strong>UA-XXXXX-X</strong>）'
-    LogosIconsTab: '商标/ 图标'
-    SocialMediaTab: 社会媒体
+    SocialMediaTab: '社会媒体'
     TwitterField: 'Twitter 用户名'
     TwitterFieldDesc: 'Twitter 用户名 (eg, http://twitter.com/<strong>username</strong>)'
   CWP\CWP\Model\Quicklink:
-    ExternalLinkLabel: 外部链接
-    InternalLinkLabel: 内部链接
+    ExternalLinkLabel: '外部链接'
+    InternalLinkLabel: '内部链接'
     NameLabel: 姓名
-    Note: '<div class="message good notice">请注意：如果您指定一个外部链接，内部链接将被忽略。</div>'
-    Note2: '<p>使用该选项指定到页面或网站（内部链接）或其他网站（外部链接）的链接。</p>'
     PLURALNAME: 快速链接
     ParentRelationLabel: 父
     SINGULARNAME: 快速链接
-    SortOrderLabel: 排序顺序
+    SortOrderLabel: '排序顺序'
   CWP\CWP\PageTypes\BaseHomePage:
-    AddNewButton: 新增
-    DESCRIPTION: 通用内容页面
-    FeatureButtonText: 按钮文字
-    FeatureCategoryDropdown: 类别图标
+    AddNewButton: '新增'
+    FeatureButtonText: '按钮文字'
+    FeatureCategoryDropdown: '类别图标'
     FeatureContentFieldLabel: 内容
-    FeatureLink: 跳转目标页
-    LearnMoreLink: 链接到“了解详情”按钮的页面：
+    FeatureLink: '跳转目标页'
+    LearnMoreLink: '链接到“了解详情”按钮的页面：'
     Title: 标题
   CWP\CWP\PageTypes\BasePage:
-    ColumnPageType: 页面类型
+    ColumnPageType: '页面类型'
     ColumnTitle: 题目
-    DESCRIPTION: 通用内容页面
-    PLURALNAME: 基本页面
-    RelatedPages: 相关页面
-    SINGULARNAME: 基本页面
+    PLURALNAME: '基本页面'
+    RelatedPages: '相关页面'
+    SINGULARNAME: '基本页面'
     TagsTabTitle: 标签
     Taxonomy: 分类法
     Term: 条款
     Terms: 条款
   CWP\CWP\PageTypes\DatedUpdateHolder:
-    DESCRIPTION: 通用内容页面
-    DateRangeFilterMessage: 用单一日期过滤。
-    FilterAppliedMessage: 所获取的数据已经应用了筛选器。
-    PLURALNAME: 基本页面
-    SINGULARNAME: 日期更新持有者
+    PLURALNAME: '基本页面'
+    SINGULARNAME: '日期更新持有者'
   CWP\CWP\PageTypes\DatedUpdatePage:
     AbstractDesc: '此摘要在清单页面用作概要。其上限是 160 个字符。'
     AbstractTextFieldLabel: 摘要
-    AuthorFieldLabel: 作者
-    DESCRIPTION: 通用内容页面
     DateLabel: 日期
-    EndTimeFieldLabel: 结束时间
-    FeaturedImageFieldLabel: 特色图片
-    LocationFieldLabel: 位置
-    SINGULARNAME: 日期更新页面
-    StartTimeFieldLabel: 开始时间
+    SINGULARNAME: '日期更新页面'
   CWP\CWP\PageTypes\EventHolder:
-    DESCRIPTION: 事件页面的容器页面，提供事件筛选与分页导航
-    PLURALNAME: 基页
-    SINGULARNAME: 事件举办者
-    Upcoming: 后续事件
+    DESCRIPTION: '事件页面的容器页面，提供事件筛选与分页导航'
+    PLURALNAME: '基页'
+    SINGULARNAME: '事件举办者'
+    Upcoming: '后续事件'
   CWP\CWP\PageTypes\EventPage:
-    DESCRIPTION: 描述特定日期发生的事件
-    SINGULARNAME: 活动页面
+    DESCRIPTION: '描述特定日期发生的事件'
+    SINGULARNAME: '活动页面'
   CWP\CWP\PageTypes\FooterHolder:
-    DESCRIPTION: 举办者页面将所有子页面显示为页脚的链接
-    PLURALNAME: 基本页面
-    SINGULARNAME: 脚注持有者
+    DESCRIPTION: '举办者页面将所有子页面显示为页脚的链接'
+    PLURALNAME: '基本页面'
+    SINGULARNAME: '脚注持有者'
   CWP\CWP\PageTypes\NewsHolder:
-    DESCRIPTION: 新闻页面的容器页面，提供新闻筛选与分页导航
-    PLURALNAME: 基本页面
-    SINGULARNAME: 新举办者
+    DESCRIPTION: '新闻页面的容器页面，提供新闻筛选与分页导航'
+    PLURALNAME: '基本页面'
+    SINGULARNAME: '新举办者'
   CWP\CWP\PageTypes\NewsPage:
-    DESCRIPTION: 描述一则新闻
-    SINGULARNAME: 新闻页面
+    DESCRIPTION: '描述一则新闻'
+    SINGULARNAME: '新闻页面'
   CWP\CWP\PageTypes\SitemapPage:
-    DESCRIPTION: 列出站点上的所有页面
-    SINGULARNAME: 站点地图页面
+    DESCRIPTION: '列出站点上的所有页面'
+    SINGULARNAME: '站点地图页面'

--- a/src/Report/CwpStatsReport.php
+++ b/src/Report/CwpStatsReport.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace CWP\CWP\Report;
+
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Folder;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\Forms\GridField\GridFieldExportButton;
+use SilverStripe\Forms\GridField\GridFieldPrintButton;
+use SilverStripe\Forms\GridField\GridFieldSortableHeader;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Reports\Report;
+use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Summary report on the page and file counts managed by this CMS.
+ */
+class CwpStatsReport extends Report
+{
+    public function title()
+    {
+        return _t(__CLASS__ . '.Title', 'Summary statistics');
+    }
+
+    public function description()
+    {
+        return _t(
+            __CLASS__ . '.Description',
+            'This report provides various statistics for this site. The "total live page count" is the number that ' .
+                'can be compared against the instance size specifications.'
+        );
+    }
+
+    public function columns()
+    {
+        return [
+            'Name' => _t(__CLASS__ . '.Name', 'Name'),
+            'Count' => _t(__CLASS__ . '.Count', 'Count'),
+        ];
+    }
+
+    /**
+     * Manually create source records for the report. Agreggates cannot be provided as a column of a DataQuery result.
+     *
+     * {@inheritDoc}
+     */
+    public function sourceRecords($params = [], $sort = null, $limit = null)
+    {
+        $records = [];
+
+        // Get the query to apply across all variants: looks at all subsites, translations, live stage only.
+        $crossVariant = (function ($dataQuery) {
+            $params = [
+                'Subsite.filter' => false,
+                'Versioned.mode' => 'stage',
+                'Versioned.stage' => Versioned::LIVE,
+            ];
+
+            return $dataQuery->setDataQueryParam($params);
+        });
+
+        // Total.
+        $records[] = [
+            'Name' => _t(
+                __CLASS__ . '.TotalPageCount',
+                'Total live page count, across all translations and subsites'
+            ),
+            'Count' => $crossVariant(SiteTree::get())->count(),
+        ];
+
+        if (class_exists(Subsite::class)) {
+            // Main site.
+            $records[] = [
+                'Name' => _t(__CLASS__ . '.PagesForMainSite', '- in the main site'),
+                'Count' => $crossVariant(SiteTree::get())
+                    ->filter(['SubsiteID' => 0])
+                    ->count(),
+            ];
+
+            // Per subsite.
+            $subsites = Subsite::get();
+            foreach ($subsites as $subsite) {
+                $records[] = [
+                    'Name' => _t(
+                        __CLASS__ . '.PagesForSubsite',
+                        "- in the subsite '{SubsiteTitle}'",
+                        ['SubsiteTitle' => $subsite->Title]
+                    ),
+                    'Count' => $crossVariant(SiteTree::get())
+                        ->filter(['SubsiteID' => $subsite->ID])
+                        ->count(),
+                ];
+            }
+        }
+
+        // Files.
+        $records[] = [
+            'Name' => _t(__CLASS__ . '.FileCount', 'File count'),
+            'Count' => File::get()
+                ->setDataQueryParam('Subsite.filter', false)
+                ->filter(['ClassName:not' => Folder::class])
+                ->count(),
+        ];
+
+        return ArrayList::create($records);
+    }
+
+    /**
+     * @return GridField
+     */
+    public function getReportField()
+    {
+        /** @var GridField $gridField */
+        $gridField = parent::getReportField();
+
+        /** @var GridFieldConfig $gridConfig */
+        $gridConfig = $gridField->getConfig();
+        $gridConfig->removeComponentsByType(GridFieldPrintButton::class);
+        $gridConfig->removeComponentsByType(GridFieldExportButton::class);
+        $gridConfig->removeComponentsByType(GridFieldSortableHeader::class);
+
+        return $gridField;
+    }
+}

--- a/tests/Report/CwpStatsReportTest.php
+++ b/tests/Report/CwpStatsReportTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace CWP\CWP\Tests\Report;
+
+use CWP\CWP\Report\CwpStatsReport;
+use Page;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Subsites\Model\Subsite;
+
+class CwpStatsReportTest extends SapphireTest
+{
+    protected static $fixture_file = 'CwpStatsReportTest.yml';
+
+    public function testCount()
+    {
+        // Publish all pages apart from page3.
+        $this->objFromFixture(Page::class, 'page1')->publishRecursive();
+        $this->objFromFixture(Page::class, 'page2')->publishRecursive();
+        $this->objFromFixture(Page::class, 'page3')->publishRecursive();
+
+        // Add page5s to a subsite, if the module is installed.
+        $page5s = $this->objFromFixture(Page::class, 'page5s');
+        if (class_exists(Subsite::class)) {
+            $subsite = Subsite::create();
+            $subsite->Title = 'subsite';
+            $subsite->write();
+
+            $page5s->SubsiteID = $subsite->ID;
+            $page5s->write();
+        }
+        $page5s->publishRecursive();
+
+        $report = CwpStatsReport::create();
+        $records = $report->sourceRecords([])->toArray();
+        $i = 0;
+        $this->assertEquals($records[$i++]['Count'], 4, 'Four pages in total, across locales, subsites, live only.');
+        if (class_exists(Subsite::class)) {
+            $this->assertEquals($records[$i++]['Count'], 3, 'Three pages in the main site, if subsites installed.');
+            $this->assertEquals($records[$i++]['Count'], 1, 'One page in the subsite, if subsites installed');
+        }
+        $this->assertEquals($records[$i++]['Count'], 1, 'One file in total.');
+    }
+}

--- a/tests/Report/CwpStatsReportTest.yml
+++ b/tests/Report/CwpStatsReportTest.yml
@@ -1,0 +1,17 @@
+Page:
+  page1:
+    Title: page1
+    Locale: en_NZ
+  page2:
+    Title: page2
+    Locale: pl_PL
+  page3:
+    Title: page3
+  page4:
+    Title: page4 - not published
+  page5s:
+    Title: page5s
+
+SilverStripe\Assets\File:
+  file1:
+    Title: file1


### PR DESCRIPTION
As part of https://github.com/silverstripe/cwp-core/pull/20, we're moving the CwpStatsReport class, tests and translations from cwp-core into this module.

Commit 41afae3 is an automated pull from Transifex and can be ignored - was just to ensure we don't overwrite and lose new translations.