### PR TITLE
FIX: Fixes exception thrown where BasePage incorrectly declares $many_many_extraFields

### DIFF
--- a/src/PageTypes/BasePage.php
+++ b/src/PageTypes/BasePage.php
@@ -17,6 +17,7 @@ use SilverStripe\View\ArrayData;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
 use UndefinedOffset\SortableGridField\Forms\GridFieldSortableRows;
+use SilverStripe\ORM\FieldType\DBInt;
 
 /**
  * **BasePage** is the foundation which can be used for constructing your own pages.
@@ -59,9 +60,13 @@ class BasePage extends SiteTree
         'RelatedPages' => BasePage::class,
     ];
 
+    /**
+     * @var array
+     * @config
+     */
     private static $many_many_extraFields = [
         'RelatedPages' => [
-            'SortOrder' => 'Int',
+            'SortOrder' => DBInt::class,
         ],
     ];
 


### PR DESCRIPTION
`GridFieldSortableRows` would report on a bad `SortableRows` config thus: `Sort column SortOrder must be an SilverStripe\ORM\FieldType\DBInt, column is of type Int`. After applying this patch, the error goes away and I can once again sort properly. Reproduction via addition of >=1 "RelatedPage".