### PR TITLE
FIX Do not run userforms or advancedworkflow tests or task if not installed

### DIFF
--- a/src/Tasks/PopulateThemeSampleDataTask.php
+++ b/src/Tasks/PopulateThemeSampleDataTask.php
@@ -29,6 +29,9 @@ class PopulateThemeSampleDataTask extends BuildTask
      */
     public function run($request)
     {
+        if (!class_exists(UserDefinedForm::class)) {
+            return;
+        }
         $this->handleContactForm();
     }
 

--- a/tests/Extensions/WorkflowDefinitionExtensionTest.php
+++ b/tests/Extensions/WorkflowDefinitionExtensionTest.php
@@ -29,6 +29,10 @@ class WorkflowDefinitionExtensionTest extends FunctionalTest
      */
     public function testCreateDefaultWorkflowTest()
     {
+        if (!class_exists(WorkflowDefinition::class)) {
+            $this->markTestSkipped('This test requires the advancedworkflow module to be installed');
+        }
+
         DB::quiet();
 
         // test disabling the default workflow definition

--- a/tests/Tasks/PopulateThemeSampleDataTaskTest.php
+++ b/tests/Tasks/PopulateThemeSampleDataTaskTest.php
@@ -17,6 +17,10 @@ class PopulateThemeSampleDataTaskTest extends SapphireTest
      */
     public function testOnlyCreateContactFormOnce()
     {
+        if (!class_exists(UserDefinedForm::class)) {
+            $this->markTestSkipped('This test requires the userforms module to be installed');
+        }
+
         $createdMessage = 'Created "contact" UserDefinedForm';
 
         $task = new PopulateThemeSampleDataTask;


### PR DESCRIPTION
In preparation for the cwp/cwp-recipe-cms testsuite, which doesn't include these modules