### PR TITLE
FIX swap GridField re-ordering component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "require": {
         "cwp/cwp-core": "^2",
         "silverstripe/cms": "^4",
-        "silverstripe/taxonomy": "^2"
+        "silverstripe/taxonomy": "^2",
+        "symbiote/silverstripe-gridfieldextensions": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/PageTypes/BaseHomePage.php
+++ b/src/PageTypes/BaseHomePage.php
@@ -17,7 +17,7 @@ use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\ToggleCompositeField;
 use SilverStripe\Forms\TreeDropdownField;
-use UndefinedOffset\SortableGridField\Forms\GridFieldSortableRows;
+use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
 /**
  * **BaseHomePage** is the basic home page.
@@ -92,7 +92,7 @@ class BaseHomePage extends Page
             $gridConfig->removeComponentsByType(GridFieldAddExistingAutocompleter::class);
             $gridConfig->removeComponentsByType(GridFieldDeleteAction::class);
             $gridConfig->addComponent($injector->create(GridFieldDeleteAction::class));
-            $gridConfig->addComponent($injector->create(GridFieldSortableRows::class, 'SortOrder'));
+            $gridConfig->addComponent($injector->create(GridFieldOrderableRows::class, 'SortOrder'));
             $gridField->setModelClass(Quicklink::class);
 
             $fields->addFieldToTab('Root.Quicklinks', $gridField);

--- a/src/PageTypes/BasePage.php
+++ b/src/PageTypes/BasePage.php
@@ -16,7 +16,7 @@ use SilverStripe\Taxonomy\TaxonomyTerm;
 use SilverStripe\View\ArrayData;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
-use UndefinedOffset\SortableGridField\Forms\GridFieldSortableRows;
+use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use SilverStripe\ORM\FieldType\DBInt;
 
 /**
@@ -98,7 +98,7 @@ class BasePage extends SiteTree
             $components->removeComponentsByType(GridFieldAddNewButton::class);
             $components->removeComponentsByType(GridFieldEditButton::class);
             $components->removeComponentsByType(GridFieldFilterHeader::class);
-            $components->addComponent(new GridFieldSortableRows('SortOrder'));
+            $components->addComponent(new GridFieldOrderableRows('SortOrder'));
 
             /** @var GridFieldDataColumns $dataColumns */
             $dataColumns = $components->getComponentByType(GridFieldDataColumns::class);


### PR DESCRIPTION
`undefinedoffset/sortablegridfield` is a good tool, however will not
be supported in the future by our (SilverStripe Ltd.) maintenance team.
The other option of `symbiote/silverstripe-gridfieldextensions` however
will remain supported (as it includes more functionality than just
sorting rows), so we'll use this and add it as a dependency here
instead. We are doing this to reduce maintenance overhead of two modules
that solve the same problem.


This prevents the runtime error in the CMS at current where a user tries to access a Page or HomePage, a fatal error is emitted as `SortableGridField` is not listed as a dependency in any project pulled in by `cwp/cwp-installer`.