### PR TITLE
Review (and update) DOCS in context of CWP 2.0 and SilverStripe 4

### DIFF
--- a/docs/en/00_Getting_started.md
+++ b/docs/en/00_Getting_started.md
@@ -12,7 +12,7 @@ This guide assumes you already have:
 
 * A server with [Apache, MySQL and PHP](working_with_projects/setting_up_a_development_environment)
 * [Git version control](working_with_projects/setting_up_a_development_environment/#git)
-* [Composer](https://docs.silverstripe.org/en/3/getting_started/composer/)
+* [Composer](https://docs.silverstripe.org/en/4/getting_started/composer/)
 
 If you're using Windows, you can use a command-line equivalent to interact with git and composer, offered by the [MsysGit package](http://msysgit.github.io)
 
@@ -34,14 +34,14 @@ Please replace "my-project" below with the actual name of your project. One nami
 This may take some time to run as it is collecting and downloading all the code required to run a default SilverStripe CMS website on CWP (the `Recipe` code).
 3. If composer asks `Do you want to remove the existing VCS (.git, .svn..) history? [Y,n]` then choose Y. This removes the existing cwp-installer history so you can turn this into your own project.
 4. `cd my-project` to move into your new project folder
-5. Make sure your folder permissions are correctly set (see [File permission problems](https://docs.silverstripe.org/en/3/getting_started/installation/common_problems/#i-ve-got-file-permission-problems-during-installation)), you will also need to create an 'assets' folder if one isn't already created
-6. Create a `_ss_environment.php` environment file in the `/htdocs` folder and fill it in with your local details
+5. Make sure your folder permissions are correctly set (see [File permission problems](https://docs.silverstripe.org/en/4/getting_started/installation/common_problems/#i-ve-got-file-permission-problems-during-installation)), you will also need to create an 'assets' folder if one isn't already created
+6. Create a `.env` environment file in the `/htdocs` folder and fill it in with your local details
 
  * [CWP Environment variables](working_with_projects/cwp_environment_variables/) has more details about CWP specific variables that you can set in your environment file
- * [Environment management](https://docs.silverstripe.org/en/4/getting_started/environment_management/) for more details about how to create a environment file
- * Adding `define('SS_SEND_ALL_EMAILS_TO', 'your@address.govt.nz');` stops any debugging emails going out accidentally to live emails
+ * [Environment management](https://docs.silverstripe.org/en/4/getting_started/environment_management/) has more details about how to create a environment file
+ * Adding `SS_SEND_ALL_EMAILS_TO='your@address.govt.nz'` stops any debugging emails going out accidentally to live emails
 
-7. Now run a build of the database either by going to `http://localhost/my-project/dev/build?flush=1` or using [Sake](https://docs.silverstripe.org/en/4/developer_guides/cli/) to run the dev/build via the command line `./framework/sake dev/build`
+7. Now run a build of the database either by going to `http://localhost/my-project/dev/build?flush=1` or using [Sake](https://docs.silverstripe.org/en/4/developer_guides/cli/) to run the dev/build via the command line `vendor/bin/sake dev/build`
 
 You should now be able to visit: http://localhost/my-project and see a basic CWP-themed site in your browser.
 

--- a/docs/en/00_Getting_started.md
+++ b/docs/en/00_Getting_started.md
@@ -22,7 +22,7 @@ Follow the instructions at [Setting up your project](working_with_projects/setti
 
 ## Getting started with CWP codebase from scratch:
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 Please replace "my-project" below with the actual name of your project. One naming technique is to use the intended project's hostname e.g. "my-project.govt.nz" as the project's folder name
 </div>
 
@@ -33,15 +33,15 @@ Please replace "my-project" below with the actual name of your project. One nami
 
 This may take some time to run as it is collecting and downloading all the code required to run a default SilverStripe CMS website on CWP (the `Recipe` code).
 3. If composer asks `Do you want to remove the existing VCS (.git, .svn..) history? [Y,n]` then choose Y. This removes the existing cwp-installer history so you can turn this into your own project.
-3. `cd my-project` to move into your new project folder
-4. Make sure your folder permissions are correctly set (see [File permission problems](https://docs.silverstripe.org/en/3/getting_started/installation/common_problems/#i-ve-got-file-permission-problems-during-installation)), you will also need to create an 'assets' folder if one isn't already created
-5. Create a `_ss_environment.php` environment file in the `/htdocs` folder and fill it in with your local details
+4. `cd my-project` to move into your new project folder
+5. Make sure your folder permissions are correctly set (see [File permission problems](https://docs.silverstripe.org/en/3/getting_started/installation/common_problems/#i-ve-got-file-permission-problems-during-installation)), you will also need to create an 'assets' folder if one isn't already created
+6. Create a `_ss_environment.php` environment file in the `/htdocs` folder and fill it in with your local details
 
  * [CWP Environment variables](working_with_projects/cwp_environment_variables/) has more details about CWP specific variables that you can set in your environment file
- * [Environment management](https://docs.silverstripe.org/en/3/getting_started/environment_management/) for more details about how to create a environment file
+ * [Environment management](https://docs.silverstripe.org/en/4/getting_started/environment_management/) for more details about how to create a environment file
  * Adding `define('SS_SEND_ALL_EMAILS_TO', 'your@address.govt.nz');` stops any debugging emails going out accidentally to live emails
 
-6. Now run a build of the database either by going to `http://localhost/my-project/dev/build?flush=1` or using [Sake](https://docs.silverstripe.org/en/3/developer_guides/cli/) to run the dev/build via the command line `./framework/sake dev/build`
+7. Now run a build of the database either by going to `http://localhost/my-project/dev/build?flush=1` or using [Sake](https://docs.silverstripe.org/en/4/developer_guides/cli/) to run the dev/build via the command line `./framework/sake dev/build`
 
 You should now be able to visit: http://localhost/my-project and see a basic CWP-themed site in your browser.
 
@@ -51,7 +51,7 @@ Even if you already know how to develop in SilverStripe, please review our
 
 ## Troubleshooting
 
-*Q: I cannot complete the composer install command. PHP says: "Fatal error: Allowed memory size of 134217728 bytes
+*Q: I can't complete the composer install command. PHP says: "Fatal error: Allowed memory size of 134217728 bytes
 exhausted (tried to allocate 71 bytes) in phar:///usr/bin/composer"*
 
 A: Some of the modules that composer needs e.g. "framework" and "cms" are rather large and composer needs more memory to

--- a/docs/en/01_Working_with_projects/00_Setting_up_a_development_environment.md
+++ b/docs/en/01_Working_with_projects/00_Setting_up_a_development_environment.md
@@ -11,12 +11,12 @@ CWP projects are installed using the Composer PHP package management tool. For g
 the [SilverStripe Composer documentation](https://docs.silverstripe.org/en/3/getting_started/composer/) or read the
 installation documentation on the [Composer site](http://getcomposer.org/doc/00-intro.md).
 
-Please familiarise yourself with [CWP recipes](recipes_and_supported_modules) before starting to develop on CWP. To ensure your code works
+Please familiarise yourself with the [CWP recipes](recipes_and_supported_modules) before starting to develop on CWP. To ensure your code works
 smoothly with the platform it's important to either start from the stable release of
-[cwp-installer](https://gitlab.cwp.govt.nz/cwp/cwp-installer/) or include
-[cwp-recipe-basic](https://gitlab.cwp.govt.nz/cwp/cwp-recipe-basic/) in your `composer.json`.
+[cwp-installer](https://github.com/silverstripe/cwp-installer) or include
+your desired [CWP recipes](recipes_and_supported_modules) in your `composer.json`.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 To ensure security of your site and CWP in general make sure your code can be upgraded - maintain your modules using
 composer. Then keep your dependencies updated with respect to the patch and sub-patch versions of the recipe - read
 more about [CWP recipes](recipes_and_supported_modules).

--- a/docs/en/01_Working_with_projects/00_Setting_up_a_development_environment.md
+++ b/docs/en/01_Working_with_projects/00_Setting_up_a_development_environment.md
@@ -17,9 +17,9 @@ smoothly with the platform it's important to either start from the stable releas
 your desired [CWP recipes](recipes_and_supported_modules) in your `composer.json`.
 
 <div class="alert alert-info" markdown='1'>
-To ensure security of your site and CWP in general make sure your code can be upgraded - maintain your modules using
-composer. Then keep your dependencies updated with respect to the patch and sub-patch versions of the recipe - read
-more about [CWP recipes](recipes_and_supported_modules).
+To ensure security of your site, and of CWP in general, please make sure your code can be easily upgraded by 
+maintaining your modules using composer. This will help to keep your dependencies updated with respect to the patch and 
+sub-patch versions of the recipe - read more about [CWP recipes](recipes_and_supported_modules).
 </div>
 
 Another reason why it's best to maintain your modules using composer is that this will allow you to easily share the

--- a/docs/en/01_Working_with_projects/01_Setting_up_your_project.md
+++ b/docs/en/01_Working_with_projects/01_Setting_up_your_project.md
@@ -27,7 +27,7 @@ access to. Access a project from here to find more information including the rep
 #### Project details
 ![GitLab project repository URL](/_images/gitlab-project-repo-url.jpg)
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 Use HTTPS address for interacting with your repository - SSH transport is not available currently.
 </div>
 
@@ -47,22 +47,22 @@ Use HTTPS address for interacting with your repository - SSH transport is not av
 
 This may take some time to run. There is some more information on these steps in the [Getting Started guide](../getting_started).
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 Assuming you followed through the "Setting up an development environment" guide, you can skip straight to "[Accessing the site](../working_with_projects/setting_up_your_project#accessing-the-site-2)" now.
 </div>
 
 ### Creating a new project?
 The preferred way to set up a new repository is to use the
-[cwp-installer](https://gitlab.cwp.govt.nz/cwp/cwp-installer/) module via Composer. Follow the instructions at [Getting Started](../getting_started) which will step you through how to create a project from scratch.
+[cwp-installer](https://github.com/silverstripe/cwp-installer) module via Composer. Follow the instructions at [Getting Started](../getting_started) which will step you through how to create a project from scratch.
 
 ## Making your first project commit
 You will need to make your first commit to Git and push your project into your Git repository provided on GitLab when you signed up for CWP.
 
 As mentioned you should not commit the packages of code managed by Composer to your project. To ensure this you need to use a `.gitignore` file stored in the root of your project (you should already have one of these files from the installation process).
 
-Inside the `.gitignore` you store references to the folders in your project you DO NOT want committed to your project Git repository.
+Inside the `.gitignore` you store references to the folders in your project you DON'T want committed to your project Git repository.
 
-For example a `.gitignore` for a CWP recipe codebase might include:
+For example, a `.gitignore` for a CWP recipe codebase might include:
 
     _ss_environment.php
     .buildpath
@@ -134,7 +134,7 @@ format of "my-agency/basic" - "cwp" namespace is reserved for platform-endorsed 
 
 ## Troubleshooting
 
-*Q: I cannot run "git remote add". git says: "fatal: remote origin already exists"*
+*Q: I can't run "git remote add". git says: "fatal: remote origin already exists"*
 
 A: If you've installed via the cwp-installer package and answered "no" the the question if the repository should be removed, the git remote named "origin" still exists and points at its git repository. You have two options:
 

--- a/docs/en/01_Working_with_projects/01_Setting_up_your_project.md
+++ b/docs/en/01_Working_with_projects/01_Setting_up_your_project.md
@@ -61,15 +61,7 @@ Inside the `.gitignore` you store references to the folders in your project you 
 
 For example, a `.gitignore` for a CWP recipe codebase might include:
 
-    /.buildpath
     /.env
-    /.project
-    /.settings
-    /.solr
-    /cms
-    /cwp
-    /cwp-core
-    /public/resources/
     /resources/
     /silverstripe-cache/
     /themes/simple/

--- a/docs/en/01_Working_with_projects/01_Setting_up_your_project.md
+++ b/docs/en/01_Working_with_projects/01_Setting_up_your_project.md
@@ -27,23 +27,20 @@ access to. Access a project from here to find more information including the rep
 #### Project details
 ![GitLab project repository URL](/_images/gitlab-project-repo-url.jpg)
 
-<div class="alert alert-info" markdown='1'>
-Use HTTPS address for interacting with your repository - SSH transport is not available currently.
-</div>
+1. Now that you have the repository URL for the project, you can check it out in your development environment with the 
+following command:
 
-1. Now that you have the repository URL for the project, you can check it out in your development environment with the following command:
-
-	git clone https://gitlab.cwp.govt.nz/my-agency/my-project.git /path/to/webroot/myproject
+    `git clone https://gitlab.cwp.govt.nz/my-agency/my-project.git /path/to/webroot/myproject`
 
 2. Replace `/path/to/webroot/myproject` with the path on your computer where you wish to store the project code.
 
 3. Then navigate to your project folder:
-
-	cd /path/to/webroot/myproject
+	
+    `cd /path/to/webroot/myproject`
 
 4. To install the SilverStripe CMS packages required for the project to run use the following command:
 
-	composer install
+    `composer install`
 
 This may take some time to run. There is some more information on these steps in the [Getting Started guide](../getting_started).
 
@@ -64,18 +61,19 @@ Inside the `.gitignore` you store references to the folders in your project you 
 
 For example, a `.gitignore` for a CWP recipe codebase might include:
 
-    _ss_environment.php
-    .buildpath
-    .project
-    .settings
-    .solr
-    .ea
-    .idea
-    .DS_Store
-    .env/framework
+    /.buildpath
+    /.env
+    /.project
+    /.settings
+    /.solr
     /cms
     /cwp
     /cwp-core
+    /public/resources/
+    /resources/
+    /silverstripe-cache/
+    /themes/simple/
+    /vendor/
     ...
 
 You can also install a Git hook module which will auto-generate this for you. [See here for more information](https://docs.silverstripe.org/en/4/getting_started/composer/#installing-and-enabling-the-ssautogitignore-package).
@@ -101,7 +99,7 @@ At this stage you should be able to run the website on the default theme include
 in your browser (assuming that your LAMP stack is properly configured).
 
 <div class="hint" markdown='1'>
-You might need to configure your admin access credentials in the `_ss_environment.php` file to be able to access the
+You might need to configure your admin access credentials in the `.env` file to be able to access the
 site (see [environment management](https://docs.silverstripe.org/en/4/getting_started/environment_management/) docs).
 </div>
 
@@ -114,9 +112,6 @@ The CWP recipe codebase includes the following directories that are either part 
  - `vendor/` - Used by composer for SilverStripe as well as 3rd party dependencies and tools (Composer).
  - `composer.json` - List of dependencies included in project. Human-readable, can be edited directly to include new modules. Inspected when `composer update` is run to determine any new versions of dependencies (Project).
  - `composer.lock` - Auto-generated, less human-readable. Tracks the exact state of the installed code modules. Used when `composer install` command is run and ensures other developers end up with same set of code (Project).
-
-The rest of the folders in a project are SilverStripe CMS code packages managed by the Composer tool.
-You should take care not to modify these module files, and should not commit these to your project (you instead commit a reference to these in your composer.json and composer.lock files).
 
 Periodically you will need to update modules to the newest versions by invoking `composer update` and committing
 the resulting `composer.lock` file.

--- a/docs/en/01_Working_with_projects/02_Maintaining_your_code.md
+++ b/docs/en/01_Working_with_projects/02_Maintaining_your_code.md
@@ -27,7 +27,7 @@ It's recommended that you don't modify third party module code in place, nor com
 Modules are meant to be reusable between multiple agencies, so if there is a problem with a supported module included with CWP, submit a pull request to that module's github repository so the fix can be included in future releases. If you are unable to find a fix to make a pull request, you can log an issue instead of a pull request in a similar manner.
 
 This makes it easy to maintain the site by switching module versions at desired moments so this doesn't happen randomly.
-Deploynaut (our deployment tool) will never modify the module versions listed in `composer.lock`, so it's up to the
+Dashboard (our deployment tool) will never modify the module versions listed in `composer.lock`, so it's up to the
 site developer to choose right versions via `composer.json`, and to run `composer update` at the right moments. Ensure you test updated modules thoroughly before deploying a new `composer.lock` file.
 
 You can also create private modules in GitLab for even better modularity. See [working with modules](working_with_modules)

--- a/docs/en/01_Working_with_projects/03_Recipes_and_supported_modules.md
+++ b/docs/en/01_Working_with_projects/03_Recipes_and_supported_modules.md
@@ -1,24 +1,165 @@
 title: Recipes and supported modules
-summary: Information about the default CWP codebase referred to as the CWP Recipe.
+summary: Information about the default CWP codebase referred to as the CWP recipes.
 
-# CWP recipe
+# CWP recipes
 
 CWP supplies developers with a default set of packages for setting up their SilverStripe CMS projects.
-The [cwp-installer](https://github.com/silverstripe/cwp-installer) package is created from the original
-[silverstripe-installer](https://github.com/silverstripe/silverstripe-installer). It can be used as a base for
+The [Common Web Platform Installer](https://github.com/silverstripe/cwp-installer)) package is created from the original
+[installer for SilverStripe CMS and Framework](https://github.com/silverstripe/silverstripe-installer). It can be used as a base for
 jump-starting development of a CWP project. This is a recommended way of creating a CWP project.
 
-The installer comes with a `composer.json` file which defines dependencies. These make up the feature set of a default CWP ready website by
-pulling sets of commercially supported SilverStripe CMS modules.
+The installer comes with a `composer.json` file which defines dependencies. These make up the feature set of a default 
+CWP ready website by
+pulling sets of commercially supported SilverStripe CMS modules. 
 
-These 'metapackages' will be from now on referred to as "recipes", and are crucial elements of keeping your CWP deployment running.
+The [Common Web Platform Installer](https://github.com/silverstripe/cwp-installer) package includes the 
+[CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms), the [CWP Search Recipe](https://github.com/silverstripe/cwp-recipe-search), and the SilverStripe [Registry module](https://github.com/silverstripe/silverstripe-registry).
+
+These 'metapackages' will be from now on referred to as "recipes", and are crucial elements of keeping your CWP 
+deployment running.
+
+## CWP recipe options
+
+There are different recipe variations you can install for a CWP project. By default you get the kitchen sink (e.g. a 
+blog even if your site doesn't need one). 
+
+### [**CWP Core Recipe**](https://github.com/silverstripe/cwp-recipe-core)
+
+Core functionality only recipe for a  CWP 2.0 installation. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe Core Recipe](https://github.com/silverstripe/recipe-core) - The recipe containing framework, config, 
+and assets.
+* [CWP Core Module](https://github.com/silverstripe/cwp-core) - The CWP basic compatibility module
+* [SilverStripe Auditor](https://github.com/silverstripe/silverstripe-auditor) - The module provides audit trail logging for various events in the system
+* [SilverStripe Environment Checker](https://github.com/silverstripe/silverstripe-environmentcheck) - The module adds automated checks to monitor an environment's health status
+* [Hybrid Sessions](https://github.com/silverstripe/silverstripe-hybridsessions) - The module adds a hybrid cookie/database session store for SilverStripe
+* [MIME Upload Validator](https://github.com/silverstripe/silverstripe-mimevalidator) - The module checks that uploaded file content roughly matches a known MIME type for the file extension
+
+### [**CWP CMS Recipe**](https://github.com/silverstripe/cwp-recipe-cms) 
+
+An extra CMS functionality recipe for a CWP 2.0 installation. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe CMS Recipe](https://github.com/silverstripe/recipe-cms) - The recipe containing CMS, versioned, asset-admin, etc.
+* [CWP Core Recipe](https://github.com/silverstripe/cwp-recipe-core) - The CWP core functionality recipe
+* [CWP features module](https://github.com/silverstripe/cwp) - The modules provides additional CMS functionality, page types, configuration
+* [CWP PDF Export](https://github.com/silverstripe/cwp-pdfexport) - The module adds PDF exporting functionality to pages
+* [HTML5 Support for SilverStripe](https://github.com/silverstripe/silverstripe-html5) - The module adds further HTML5 support to the CMS
+* [SilverStripe Grid Field Extensions](https://github.com/symbiote/silverstripe-gridfieldextensions)- This module adds extra feature components for GridFields
+
+### [**CWP Search Recipe**](https://github.com/silverstripe/cwp-recipe-search) 
+
+A recipe of modules to add search functionality to your CWP 2 project. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe CMS Recipe](https://github.com/silverstripe/recipe-cms) 
+* [CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms) - The CWP CMS requirements recipe
+* [CWP Search Integration](https://github.com/silverstripe/cwp-search) - The module enables CWP fulltext search integration 
+* [FullTextSearch](https://github.com/silverstripe/silverstripe-fulltextsearch) - The module adds external full text search engine support to SilverStripe, specifically with Solr in a CWP context
+* [SilverStripe Queued Jobs](https://github.com/symbiote/silverstripe-queuedjobs) - The module provides interfaces for scheduling jobs for certain times
+
+### [**SilverStripe Authoring Tools Recipe**](https://github.com/silverstripe/recipe-authoring-tools) 
+
+Extra tools for CMS authoring in SilverStripe. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe CMS Recipe](https://github.com/silverstripe/recipe-cms)
+* [SilverStripe Document Converter](https://github.com/silverstripe/silverstripe-documentconverter) - The module adds functionality to import OpenOffice-compatible files (doc, docx, etc) into SilverStripe pages and content
+* [IFrame](https://github.com/silverstripe/silverstripe-iframe) - The module provides an IFrame page type that allows you to embed an IFrame into a page without resorting to custom code
+* [Spellcheck for SilverStripe](https://github.com/silverstripe/silverstripe-spellcheck) - The module improves spellcheck support for SilverStripe CMS, including an implementation for HunSpell
+* [Tag Field](https://github.com/silverstripe/silverstripe-tagfield) - The SilverStripe module for editing tags (both in the CMS and other forms)
+* [Taxonomy](https://github.com/silverstripe/silverstripe-taxonomy) - The module provides the capability to add and edit simple taxonomies within SilverStripe
+
+### [**SilverStripe Blog Recipe**](https://github.com/silverstripe/recipe-blog) 
+
+Adds blog functionality for your project. It includes the following core SilverStripe and CWP modules:
+
+* [Widgets](https://github.com/silverstripe/silverstripe-widgets) - The module enables the adding widget, which are small pieces of functionality 
+* [SilverStripe Content Widget](https://github.com/silverstripe/silverstripe-content-widget) - The module adds functionality to display HTML content in a widget
+* [SpamProtection](https://github.com/silverstripe/silverstripe-spamprotection) - The module provides anAPI for adding spam protection to SilverStripe forms
+* [Akismet](https://github.com/silverstripe/silverstripe-akismet) - The module adds a simple spam filter using Akismet
+* [Comments](https://github.com/silverstripe/silverstripe-comments) - The module provides commenting functionality for Pages and other DataObjects
+* [Comment Notifications](https://github.com/silverstripe/comment-notifications) - The module provides simple email notification functionality for when new visitor comments are posted. 
+* [GridField Bulk Editing Tools](https://github.com/colymba/GridFieldBulkEditingTools) - The module provides a set of GridField components to facilitate bulk file upload & record editing.
+
+### [**SilverStripe Collaboration Recipe**](https://github.com/silverstripe/recipe-collaboration) 
+
+Adds functionality to enhance CMS author collaboration. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe CMS Recipe](https://github.com/silverstripe/recipe-cms) - The recipe containing CMS, versioned, asset-admin, etc.
+* [Content Review](https://github.com/silverstripe/silverstripe-contentreview) - The module adds functionality to mark a page in SilverStripe CMS with a date and an owner for future review
+* [Share Draft Content](https://github.com/silverstripe/silverstripe-sharedraftcontent) - The modules enables the sharing of draft page content with non-CMS users
+* [Advanced Workflow Module](Advanced Workflow Module) - This module provides highly configurable step-based workflow functionality
+
+### [**SilverStripe CMS Reporting Tools Recipe**](https://github.com/silverstripe/recipe-reporting-tools) 
+
+Adds extra CMS reporting tools to your SilverStripe project. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe CMS Recipe](https://github.com/silverstripe/recipe-cms) - The recipe containing CMS, versioned, asset-admin, etc.
+* [External Links](https://github.com/silverstripe/silverstripe-externallinks) - The module tracks external broken links in SilverStripe CMS pages
+* [Reports](https://github.com/silverstripe/silverstripe-reports) The module contains the API for creating backend reports in the SilverStripe Framework
+* [Security Report](https://github.com/silverstripe/silverstripe-securityreport) - The module adds a "Users, Groups and Permissions" report in the SilverStripe CMS
+* [Site-wide Content Report](https://github.com/silverstripe/silverstripe-sitewidecontent-report) - The module adds a report of all pages and files across all the project, including subsites
+
+### [**SilverStripe Content Blocks Recipe**](https://github.com/silverstripe/recipe-content-blocks) 
+
+Adds content blocks to your SilverStripe project. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe CMS Recipe](https://github.com/silverstripe/recipe-cms) - The recipe containing CMS, versioned, asset-admin, etc.
+* [SilverStripe Elemental](https://github.com/dnadesign/silverstripe-elemental) - The module enables adding content "elements" to your pages
+* [SilverStripe Elemental Blocks](https://github.com/silverstripe/silverstripe-elemental-blocks) - The module enables adding some standard content blocks
+
+### [**SilverStripe Form Building Recipe**](https://github.com/silverstripe/recipe-form-building) 
+
+A recipe of modules to help you build forms in SilverStripe. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe CMS Recipe](https://github.com/silverstripe/recipe-cms) - The recipe containing CMS, versioned, asset-admin, etc
+* [SilverStripe Segment Field](https://github.com/silverstripe/silverstripe-segment-field) - The module provides a reusable approach to segment-generating fields
+* [UserForms](https://github.com/silverstripe/silverstripe-userforms) - The module provides a visual form builder for the SilverStripe CMS
+* [SilverStripe Queued Jobs](https://github.com/symbiote/silverstripe-queuedjobs) - The module provides interfaces for scheduling jobs for certain times
+
+### [**SilverStripe Services Recipe**](https://github.com/silverstripe/recipe-services) 
+
+Adds API and content service modules to your SilverStripe project. It includes the following core SilverStripe and CWP modules:
+
+* [SilverStripe CMS Recipe](https://github.com/silverstripe/recipe-cms) - The recipe containing CMS, versioned, asset-admin, etc.
+* [SilverStripe RestfulServer](https://github.com/silverstripe/silverstripe-restfulserver) - The RestfulServer module for SilverStripe CMS; it adds REST API capability
+* [Version Feed](https://github.com/silverstripe/silverstripe-versionfeed) - The module provides an RSS feed for global site changes
+
+<div class="alert alert-info" markdown='1'>
+Note, when installing the Services Recipe you will also install 
+[the GraphQL module](https://github.com/silverstripe/silverstripe-graphql) which is bundled with the core SilverStripe
+4 CMS. You may choose to use this over RestfulServer.
+</div>
+
+## Recipe combinations
+
+The above recipes can be combined as follows:
+
+* Bare bones - SilverStripe plus CWP mandated configuration.
+* Bare bones plus the [SilverStripe Blog Recipe](https://github.com/silverstripe/recipe-blog), or plus the [SilverStripe Form Building Recipe](https://github.com/silverstripe/recipe-form-building), etc.
+* The [Common Web Platform Installer](https://github.com/silverstripe/cwp-installer) includes all of the above.
+* The [CWP Agency Extensions Module](https://github.com/silverstripe/cwp-agencyextensions) can be added to any of the above.
+
+## Theme options
+
+There are two themes provided for the Common Web Platform 2.0 that help government agencies quickly get their sites up and running:
+
+* The [**CWP Starter theme**](https://github.com/silverstripe/cwp-starter-theme) is a developer focused highly accessible Bootstrap 3 theme. It is suited for sites that require more customisation and a design applied with minimal restrictions.
+* The [**Wātea theme**](https://github.com/silverstripe/cwp-watea-theme) includes more design elements than the CWP Starter theme. It is well suited for smaller agencies with smaller sites, smaller budgets and less developer involvement.
+
+<div class="alert alert-info" markdown='1'>
+The Wātea theme is a more "designed" subtheme which can be installed over the top of the Starter theme to provide a 
+more visually appealing starter project. It also requires the [CWP Agency Extensions Module](https://github.com/silverstripe/cwp-agencyextensions) to be installed.
+</div>
+
+## Stabilising the project
 
 Even if you did not start from the installer, you can make your project "stable" by
 including the following in your `composer.json`:
 
-	"require": {
-        "cwp/cwp-recipe-cms": "~2.0.0@stable"
-		...
+```
+"require": {
+    "cwp/cwp-recipe-cms": "~2.0.0@stable"
+    ...
+```
 
 So if the above dependency can be found in your root `composer.json` file it can be said that you are running on a
 stable CWP recipe version. If you request help from the CWP Team, this will be one of the first things that will be checked - if you are not running on a stable CWP recipe, we may not be able to easily help you.
@@ -27,21 +168,23 @@ You may add more modules to your project by modifying your base `composer.json`.
 interact with the recipe, so you need to test for regressions as only the base combination of packages is tested in the CWP recipe
 release process.
 
-## Can I remove the basic recipe?
+## Can I remove the default recipes?
 
-We strongly recommend using the basic recipe dependency for your projects.
+We strongly recommend using the supported SilverStripe and CWP recipes that come by default with a CWP installation.
 
 The reasons include:
 
-* reused code makes maintenance simple - it's easier to apply security updates
-* Service Desk might not be able to help you if you are on a heavily customised codebase
-* custom code is usually less stable than the one that's frequently used
-* advertised CWP features may not work
-* your site may break when infrastructure changes are rolled out - these changes will only be tested against the official CWP recipe releases
+* Reused code makes maintenance simple - it's easier to apply security updates
+* The CWP Service Desk might not be able to help you if you are on a heavily customised codebase
+* Custom code is usually less stable than the one that's frequently used
+* Advertised CWP features may not work
+* Your site may break when infrastructure changes are rolled out - these changes will only be tested against the official CWP recipe releases
+
+You are welcome to remove recipes or features from the list of dependencies that are not required for your project. 
 
 If after careful consideration your development team decides to depart from the recipe model, it is recommended to pull
 in at least the [CWP CMS recipe](https://github.com/silverstripe/cwp-recipe-cms). If even this doesn't work for you, the last resort is
-including the the [CWP core recipe](https://github.com/silverstripe/cwp-recipe-core). This at least will ensure the minimal compatibility
+including the [CWP Core recipe](https://github.com/silverstripe/cwp-recipe-core). This at least will ensure the minimal compatibility
 with the platform infrastructure and will allow us to deliver some subset of fixes and features to you as they are released.
 
 Your development team will need to follow the releases of the recipe on their own and make sure the modules are either
@@ -52,10 +195,8 @@ updated, or the issues acknowledged as not posing security or technical risk.
 We use [semantic versioning](http://semver.org) for the SilverStripe Framework, CMS and supported modules. In CWP recipes we use major, minor and point
 releases. From time to time the fourth level - micro (1.2.3.4) - might be used if more granularity is needed.
 
-Stable recipe releases will be triggered by the releases of the SilverStripe Framework - for example recipe 1.0.1 maps
-to framework 3.1.1 and recipe 1.0.2 will map to framework 3.1.2. Recipes may also be released outside of this cycle in
-case some important fixes need to be applied to the modules (such as security releases) - these will be numbered with
-micro versions (1.0.1.1, 1.0.1.2 and so forth).
+Stable recipe releases will often be released alongside a stable release of the core SilverStripe framework and CMS, but
+we may also release new features or bugfixes for CWP independently of this.
 
 If we announce a new point/micro recipe release (e.g. if you are on 1.0.1, these will be 1.0.1.1, 1.0.1.2, 1.0.2,
 1.0.2.1 and so forth) you will need to upgrade, test and deploy your updated project code within a relatively short
@@ -71,19 +212,17 @@ to apply. One old minor and one old major branch will still receive security pat
 We estimate that on a small site you may need to spend a day upgrading to a new minor version, and a few days or more
 upgrading to a new major version.
 
-CWP Team may in some situations hot-patch (possibly in a destructive way) your site or pull an environment down if it is
+The CWP support team may in some situations hot-patch (possibly in a destructive way) your site or pull an environment down if it is
 found to endanger other sites on the CWP infrastructure. The timeframe in which this could happen will be specified on the release
 notification.
 
-See [upgrading guide](upgrading) for instructions.
+See the [upgrading guide](upgrading) for instructions.
 
 ## Recipe contents
 
-To obtain the composition of the latest stable recipe, the easiest way is to head to the
-[recipe repositories](https://github.com/topics/cwp) and look at the respective composer file and the dependencies
+To obtain the composition of the latest stable recipes, the easiest way is to head to the
+[recipe repositories](https://github.com/topics/silverstripe-recipes) and look at the respective composer file and the dependencies
 contained there.
-
-To obtain the composition of the latest stable recipe, the easiest way is to head to the recipe's repository and look at the respective composer file, then update the dependencies contained there. 
 
 For example, [here is the blog recipe contents](https://github.com/silverstripe/recipe-blog/blob/master/composer.json).
 
@@ -93,11 +232,13 @@ To find the location of a specific repository check on [Packagist](http://packag
 
 The installer's `composer.json` also provides a single "dev" metapackage dependency for CWP:
 
-	"require-dev": {
-		"cwp/cwp-recipe-basic-dev": "~1.0.1@stable"
-		...
+```
+"require-dev": {
+    "cwp/cwp-recipe-basic-dev": "~2.0.0@stable"
+    ...
+```
 
-[cwp-recipe-basic-dev](https://gitlab.cwp.govt.nz/cwp/cwp-recipe-basic-dev/) pulls in dev dependencies specific for
+[cwp-recipe-basic-dev](https://github.com/silverstripe/cwp-recipe-basic-dev) pulls in dev dependencies specific for
 development based on the CWP codebase. These packages will NOT be installed on the environments (neither prod, UAT nor
 test). You can also elect not to install it by specifying `--no-dev` with your `composer install` or `composer update`
 commands on your local dev machine.

--- a/docs/en/01_Working_with_projects/03_Recipes_and_supported_modules.md
+++ b/docs/en/01_Working_with_projects/03_Recipes_and_supported_modules.md
@@ -5,15 +5,18 @@ summary: Information about the default CWP codebase referred to as the CWP recip
 
 CWP supplies developers with a default set of packages for setting up their SilverStripe CMS projects.
 The [Common Web Platform Installer](https://github.com/silverstripe/cwp-installer)) package is created from the original
-[installer for SilverStripe CMS and Framework](https://github.com/silverstripe/silverstripe-installer). It can be used as a base for
-jump-starting development of a CWP project. This is a recommended way of creating a CWP project.
+[installer for SilverStripe CMS and Framework](https://github.com/silverstripe/silverstripe-installer). It can be used 
+as a base for jump-starting development of a CWP project. This is a recommended way of creating a CWP project.
 
 The installer comes with a `composer.json` file which defines dependencies. These make up the feature set of a default 
-CWP ready website by
-pulling sets of commercially supported SilverStripe CMS modules. 
+CWP ready website by pulling sets of commercially supported SilverStripe CMS modules. 
 
 The [Common Web Platform Installer](https://github.com/silverstripe/cwp-installer) package includes the 
-[CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms), the [CWP Search Recipe](https://github.com/silverstripe/cwp-recipe-search), and the SilverStripe [Registry module](https://github.com/silverstripe/silverstripe-registry).
+[CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms), 
+the [CWP Search Recipe](https://github.com/silverstripe/cwp-recipe-search), 
+the [Registry module](https://github.com/silverstripe/silverstripe-registry), 
+the [Fluent module](https://github.com/tractorcow/silverstripe-fluent), and
+the [Subsites module](https://github.com/silverstripe/silverstripe-subsites).
 
 These 'metapackages' will be from now on referred to as "recipes", and are crucial elements of keeping your CWP 
 deployment running.
@@ -23,19 +26,23 @@ deployment running.
 There are different recipe variations you can install for a CWP project. By default you get the kitchen sink (e.g. a 
 blog even if your site doesn't need one). 
 
-### [**CWP Core Recipe**](https://github.com/silverstripe/cwp-recipe-core)
+### [CWP Core Recipe](https://github.com/silverstripe/cwp-recipe-core)
 
-Core functionality only recipe for a  CWP 2.0 installation. It includes the following core SilverStripe and CWP modules:
+Core functionality only recipe for a CWP 2.0 installation. It includes the following core SilverStripe and CWP modules:
 
 * [SilverStripe Core Recipe](https://github.com/silverstripe/recipe-core) - The recipe containing framework, config, 
 and assets.
-* [CWP Core Module](https://github.com/silverstripe/cwp-core) - The CWP basic compatibility module
+* [CWP Core Module](https://github.com/silverstripe/cwp-core) - The CWP platform compatibility module
 * [SilverStripe Auditor](https://github.com/silverstripe/silverstripe-auditor) - The module provides audit trail logging for various events in the system
 * [SilverStripe Environment Checker](https://github.com/silverstripe/silverstripe-environmentcheck) - The module adds automated checks to monitor an environment's health status
 * [Hybrid Sessions](https://github.com/silverstripe/silverstripe-hybridsessions) - The module adds a hybrid cookie/database session store for SilverStripe
 * [MIME Upload Validator](https://github.com/silverstripe/silverstripe-mimevalidator) - The module checks that uploaded file content roughly matches a known MIME type for the file extension
 
-### [**CWP CMS Recipe**](https://github.com/silverstripe/cwp-recipe-cms) 
+<div class="alert alert-info" markdown='1'>
+Note, that this recipe is required if you are running an Active Disaster Recovery (DR) instance. Find out more about [preparing your site for active DR](/how_tos/preparing_your_site_for_active_dr).
+</div>
+
+### [CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms) 
 
 An extra CMS functionality recipe for a CWP 2.0 installation. It includes the following core SilverStripe and CWP modules:
 
@@ -44,9 +51,9 @@ An extra CMS functionality recipe for a CWP 2.0 installation. It includes the fo
 * [CWP features module](https://github.com/silverstripe/cwp) - The modules provides additional CMS functionality, page types, configuration
 * [CWP PDF Export](https://github.com/silverstripe/cwp-pdfexport) - The module adds PDF exporting functionality to pages
 * [HTML5 Support for SilverStripe](https://github.com/silverstripe/silverstripe-html5) - The module adds further HTML5 support to the CMS
-* [SilverStripe Grid Field Extensions](https://github.com/symbiote/silverstripe-gridfieldextensions)- This module adds extra feature components for GridFields
+* [SilverStripe GridField Extensions](https://github.com/symbiote/silverstripe-gridfieldextensions)- This module adds extra feature components for GridFields
 
-### [**CWP Search Recipe**](https://github.com/silverstripe/cwp-recipe-search) 
+### [CWP Search Recipe](https://github.com/silverstripe/cwp-recipe-search) 
 
 A recipe of modules to add search functionality to your CWP 2 project. It includes the following core SilverStripe and CWP modules:
 
@@ -56,7 +63,7 @@ A recipe of modules to add search functionality to your CWP 2 project. It includ
 * [FullTextSearch](https://github.com/silverstripe/silverstripe-fulltextsearch) - The module adds external full text search engine support to SilverStripe, specifically with Solr in a CWP context
 * [SilverStripe Queued Jobs](https://github.com/symbiote/silverstripe-queuedjobs) - The module provides interfaces for scheduling jobs for certain times
 
-### [**SilverStripe Authoring Tools Recipe**](https://github.com/silverstripe/recipe-authoring-tools) 
+### [SilverStripe Authoring Tools Recipe](https://github.com/silverstripe/recipe-authoring-tools) 
 
 Extra tools for CMS authoring in SilverStripe. It includes the following core SilverStripe and CWP modules:
 
@@ -67,19 +74,20 @@ Extra tools for CMS authoring in SilverStripe. It includes the following core Si
 * [Tag Field](https://github.com/silverstripe/silverstripe-tagfield) - The SilverStripe module for editing tags (both in the CMS and other forms)
 * [Taxonomy](https://github.com/silverstripe/silverstripe-taxonomy) - The module provides the capability to add and edit simple taxonomies within SilverStripe
 
-### [**SilverStripe Blog Recipe**](https://github.com/silverstripe/recipe-blog) 
+### [SilverStripe Blog Recipe](https://github.com/silverstripe/recipe-blog) 
 
 Adds blog functionality for your project. It includes the following core SilverStripe and CWP modules:
 
-* [Widgets](https://github.com/silverstripe/silverstripe-widgets) - The module enables the adding widget, which are small pieces of functionality 
+* [Widgets](https://github.com/silverstripe/silverstripe-widgets) - The module enables the adding of widgets, which are small pieces of functionality 
 * [SilverStripe Content Widget](https://github.com/silverstripe/silverstripe-content-widget) - The module adds functionality to display HTML content in a widget
-* [SpamProtection](https://github.com/silverstripe/silverstripe-spamprotection) - The module provides anAPI for adding spam protection to SilverStripe forms
+* [SpamProtection](https://github.com/silverstripe/silverstripe-spamprotection) - The module provides an API for adding spam protection to SilverStripe forms
 * [Akismet](https://github.com/silverstripe/silverstripe-akismet) - The module adds a simple spam filter using Akismet
 * [Comments](https://github.com/silverstripe/silverstripe-comments) - The module provides commenting functionality for Pages and other DataObjects
 * [Comment Notifications](https://github.com/silverstripe/comment-notifications) - The module provides simple email notification functionality for when new visitor comments are posted. 
 * [GridField Bulk Editing Tools](https://github.com/colymba/GridFieldBulkEditingTools) - The module provides a set of GridField components to facilitate bulk file upload & record editing.
+* [SilverStripe Lumberjack](https://github.com/silverstripe/silverstripe-lumberjack) - The module enables easy managing of pages in a GridField.
 
-### [**SilverStripe Collaboration Recipe**](https://github.com/silverstripe/recipe-collaboration) 
+### [SilverStripe Collaboration Recipe](https://github.com/silverstripe/recipe-collaboration) 
 
 Adds functionality to enhance CMS author collaboration. It includes the following core SilverStripe and CWP modules:
 
@@ -88,7 +96,7 @@ Adds functionality to enhance CMS author collaboration. It includes the followin
 * [Share Draft Content](https://github.com/silverstripe/silverstripe-sharedraftcontent) - The modules enables the sharing of draft page content with non-CMS users
 * [Advanced Workflow Module](Advanced Workflow Module) - This module provides highly configurable step-based workflow functionality
 
-### [**SilverStripe CMS Reporting Tools Recipe**](https://github.com/silverstripe/recipe-reporting-tools) 
+### [SilverStripe CMS Reporting Tools Recipe](https://github.com/silverstripe/recipe-reporting-tools) 
 
 Adds extra CMS reporting tools to your SilverStripe project. It includes the following core SilverStripe and CWP modules:
 
@@ -98,7 +106,7 @@ Adds extra CMS reporting tools to your SilverStripe project. It includes the fol
 * [Security Report](https://github.com/silverstripe/silverstripe-securityreport) - The module adds a "Users, Groups and Permissions" report in the SilverStripe CMS
 * [Site-wide Content Report](https://github.com/silverstripe/silverstripe-sitewidecontent-report) - The module adds a report of all pages and files across all the project, including subsites
 
-### [**SilverStripe Content Blocks Recipe**](https://github.com/silverstripe/recipe-content-blocks) 
+### [SilverStripe Content Blocks Recipe](https://github.com/silverstripe/recipe-content-blocks) 
 
 Adds content blocks to your SilverStripe project. It includes the following core SilverStripe and CWP modules:
 
@@ -106,7 +114,7 @@ Adds content blocks to your SilverStripe project. It includes the following core
 * [SilverStripe Elemental](https://github.com/dnadesign/silverstripe-elemental) - The module enables adding content "elements" to your pages
 * [SilverStripe Elemental Blocks](https://github.com/silverstripe/silverstripe-elemental-blocks) - The module enables adding some standard content blocks
 
-### [**SilverStripe Form Building Recipe**](https://github.com/silverstripe/recipe-form-building) 
+### [SilverStripe Form Building Recipe](https://github.com/silverstripe/recipe-form-building) 
 
 A recipe of modules to help you build forms in SilverStripe. It includes the following core SilverStripe and CWP modules:
 
@@ -115,7 +123,7 @@ A recipe of modules to help you build forms in SilverStripe. It includes the fol
 * [UserForms](https://github.com/silverstripe/silverstripe-userforms) - The module provides a visual form builder for the SilverStripe CMS
 * [SilverStripe Queued Jobs](https://github.com/symbiote/silverstripe-queuedjobs) - The module provides interfaces for scheduling jobs for certain times
 
-### [**SilverStripe Services Recipe**](https://github.com/silverstripe/recipe-services) 
+### [SilverStripe Services Recipe](https://github.com/silverstripe/recipe-services) 
 
 Adds API and content service modules to your SilverStripe project. It includes the following core SilverStripe and CWP modules:
 

--- a/docs/en/01_Working_with_projects/04_Customising_the_default_functionality.md
+++ b/docs/en/01_Working_with_projects/04_Customising_the_default_functionality.md
@@ -80,7 +80,7 @@ Because all page types extend from `Page`, this will apply the editor field to *
 If you want your field to be a plain text area field instead, simply replace `HTMLText` with `Text` and
 `HtmlEditorField` with `TextareaField`.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 The "RichLinks" part of the template variable provides additional processing to the links in the content.
 [See more on the rich links functionality](cwp-features/rich_links).
 </div>

--- a/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md
+++ b/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md
@@ -99,10 +99,17 @@ also don't want to have access to your site's code as well, and will make it mor
  1. Edit your project's `.gitignore` file and remove the `themes/` line.
  2. Remove the `/themes/starter/.git` directory and the `/themes/starter/.gitignore` file.
  3. Rename the "starter" folder to your projects name (it should be all lower case and preferably one word).
-  * If you're also using the [Wātea theme](https://github.com/silverstripe/cwp-watea-theme) you will also need to change "starter" to your projects name in the "starter_watea" folder. You may also wish to change the "watea" part of that folder name to your own customised subtheme name as well. Ensure you don't remove the underscore, and that the new "starter" theme name is reflected in the folder name of the Wātea theme if changed.
- 4. Add the `.gitignore` file and the `themes` folder to your git project, commit it and push it back to the upstream repository.
- 5. Remove the "cwp/starter-theme" line from the **require** list in `composer.json`. This will prevent composer from re-adding the *starter* theme to your project.
- 6. Edit `mysite/_config/config.yml` and alter the `SSViewer: theme` setting to the name of your new theme.
+  * If you're also using the [Wātea theme](https://github.com/silverstripe/cwp-watea-theme) you will also need to 
+  change "starter" to your projects name in the "starter_watea" folder. You may also wish to change the "watea" part of 
+  that folder name to your own customised subtheme name as well. Note that if you change the theme name from "watea" to 
+  something else you will need to update it in your `theme.yml` file as well
+ 4. Add the `.gitignore` file and the `themes` folder to your git project, commit it and push it back to the upstream 
+ repository.
+ 5. Remove the "cwp/starter-theme" line from the **require** list in `composer.json`. This will prevent composer from 
+ re-adding the *starter* theme to your project.
+ 6. Edit `mysite/_config/theme.yml` and add your theme name to the list in `SilverStripe\View\SSViewer.themes`. 
+ If you're using the public webroot feature (enabled by default from CWP 2.0 onwards) ensure you add your custom theme
+  _after_ `'$public'`.
 
 <div class="alert alert-info" markdown='1'>
 Don't forget to `flush` by visiting `http://localhost/your-project/?flush=1` to get the new theme running!

--- a/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md
+++ b/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md
@@ -1,11 +1,11 @@
-title: Customising the starter theme
+title: Customising the CWP Starter theme
 summary: Development information for working with themes
 
-# Customising the starter theme
+# Customising the CWP Starter theme
 
 ## Introduction
 
-CWP provides a *starter* theme for you to work with. This has been developed both as a base for more complex themes to
+CWP provides a *CWP Starter* theme for you to work with. This has been developed both as a base for more complex themes to
 be built on top of and as a reference example for meeting Government standards and accessibility guidelines.
 
 For more information on how a SilverStripe theme is constructed, see the [Developing
@@ -15,22 +15,22 @@ When customising the theme, you can choose to work either with the powerful SASS
 use the CSS stylesheets directly. In the latter case we recommend you to remove the `.scss` files to make it clear they are
 not used.
 
-We recommend you follow the starter theme as a guideline and use the provided NPM configuration to build and recompile your frontend dependencies.
+We recommend you follow the CWP Starter theme as a guideline and use the provided npm configuration to build and recompile your frontend dependencies.
 
-<div class="notice" markdown='1'>
-Note: The starter theme is the default CWP theme as of the CWP 1.6 recipe. If you are looking for the old "default" CWP theme, [please see here](https://www.cwp.govt.nz/developer-docs/en/1.5/working_with_projects/customising_the_default_theme/).
+<div class="alert alert-info" markdown='1'>
+Note: The Starter theme is the default CWP theme as of the CWP 1.6 recipe. If you are looking for the old "default" CWP theme, [please see here](https://www.cwp.govt.nz/developer-docs/en/1.5/working_with_projects/customising_the_default_theme/).
 </div>
 
 ## Getting Started
 
-The starter theme that comes with the basic site is cloned from the [CWP starter theme in GitHub](https://github.com/silverstripe/cwp-starter-theme), so you are not able to
+The CWP Starter theme that comes with the basic site is cloned from the [CWP Starter theme in GitHub](https://github.com/silverstripe/cwp-starter-theme), so you are not able to
 make changes to it directly. There are two recommended ways of creating your own theme:
 
 ### Forking the theme
 
-This will give you a copy of the starter theme repository that you can edit and can share with others.
+This will give you a copy of the CWP Starter theme repository that you can edit and can share with others.
 
-1. Browse to the [starter theme](https://github.com/silverstripe/cwp-starter-theme) in GitHub.
+1. Browse to the [CWP Starter theme](https://github.com/silverstripe/cwp-starter-theme) in GitHub.
 2. Click on the *Fork* button in the toolbar. This will make a copy of the theme in your GitLab profile.
 3. Your forked repository has inherited the starter theme's public access. To disable this, go to the settings page.
 (*Settings / Edit Project*) of your repository in Gitlab, change the *Project Visibility* option as required and click *Save*.
@@ -94,17 +94,17 @@ GitLab hosted modules. See [Working with modules](working_with_modules) for more
 ### Committing a theme to your project repository
 
 This is a more straightforward process but not as flexible - you won't be able to share the theme with anyone that you
-also don't want to have access to your site's code as well, and will make it more difficult to update when the starter theme is updated.
+also don't want to have access to your site's code as well, and will make it more difficult to update when the CWP Starter theme is updated.
 
  1. Edit your project's `.gitignore` file and remove the `themes/` line.
  2. Remove the `/themes/starter/.git` directory and the `/themes/starter/.gitignore` file.
  3. Rename the "starter" folder to your projects name (it should be all lower case and preferably one word).
-  * If you're also using the [Wātea theme](https://github.com/silverstripe/cwp-watea-theme) you will also need to change "starter" to your projects name in the "starter_watea" folder. You may also wish to change the "watea" part of that folder name to your own customised subtheme name as well. Ensure you do not remove the underscore, and that the new "starter" theme name is reflected in the folder name of the Wātea theme if changed.
+  * If you're also using the [Wātea theme](https://github.com/silverstripe/cwp-watea-theme) you will also need to change "starter" to your projects name in the "starter_watea" folder. You may also wish to change the "watea" part of that folder name to your own customised subtheme name as well. Ensure you don't remove the underscore, and that the new "starter" theme name is reflected in the folder name of the Wātea theme if changed.
  4. Add the `.gitignore` file and the `themes` folder to your git project, commit it and push it back to the upstream repository.
  5. Remove the "cwp/starter-theme" line from the **require** list in `composer.json`. This will prevent composer from re-adding the *starter* theme to your project.
  6. Edit `mysite/_config/config.yml` and alter the `SSViewer: theme` setting to the name of your new theme.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 Don't forget to `flush` by visiting `http://localhost/your-project/?flush=1` to get the new theme running!
 </div>
 
@@ -119,7 +119,7 @@ Now when you go into GitLab, you'll see a commit from yourself "Add custom theme
 
 ## Bootstrap
 
-The *starter* theme is built on top of a fork of the [Bootstrap 3](http://getbootstrap.com/)
+The CWP Starter theme is built on top of a fork of the [Bootstrap 3](http://getbootstrap.com/)
 front-end framework.
 
 Bootstrap is a free collection of tools for creating websites and web applications. It contains HTML and
@@ -130,9 +130,9 @@ uses the Sass port of Bootstrap.
 From Bootstrap's [Getting Started page](http://getbootstrap.com/getting-started/) you can find links about the basics of the system
 and the full documentation.
 
-The starter theme's NPM dependencies include the Bootstrap Sass files, and the compiled CSS output also includes the final output.
+The CWP Starter theme's npm dependencies include the Bootstrap Sass files, and the compiled CSS output also includes the final output.
 
-### Bootstrap in the *starter* theme
+### Bootstrap in the *CWP Starter* theme
 
 If you just want to dive in without reading the manual, the most important thing to understand is the [grid
 system](https://getbootstrap.com/docs/3.3/css/#grid). In a nutshell, `.row` is a full-width
@@ -143,7 +143,7 @@ The basic page layout uses a `.col-md-7` on the left for the content and a `.col
 
 ## Sass and Javascript
 
-The starter theme is build using Bootstrap's Sass source code to compile a customised version of Bootstrap, where colours, margins, paddings etc are modified and recompiled within the context of the rest of Bootstrap's source code.
+The CWP Starter theme is build using Bootstrap's Sass source code to compile a customised version of Bootstrap, where colours, margins, paddings etc are modified and recompiled within the context of the rest of Bootstrap's source code.
 
 We've added very little CSS and JS to the core Bootstrap 3 feature set, but that which we have added is neatly packaged in the theme folder. The files are built using a build chain abstraction, called [Laravel Mix](https://laravel.com/docs/5.4/mix). It uses [Webpack](https://webpack.github.io) to convert, combine, minify and improve the quality of CSS and JS files.
 
@@ -179,9 +179,9 @@ In the above example, the "src" files are all loaded and processed (although the
 
 ### Installing Webpack and Laravel Mix
 
-You'll need to have a recent versions of [Node](https://nodejs.org/en/) and [NPM](https://www.npmjs.com/) for this build chain to work. We recommend Node `v7.x` or later and NPM `v4.x` or later. You can check which version you have by running `node -v` and `npm version`.
+You'll need to have a recent versions of [Node.js](https://nodejs.org/en/) and [npm](https://www.npmjs.com/) for this build chain to work. We recommend Node `v7.x` or later and npm `v4.x` or later. You can check which version you have by running `node -v` and `npm version`.
 
-Once you have NPM installed, you can install the required package dependencies for the theme:
+Once you have npm installed, you can install the required package dependencies for the theme:
 
 ```
 cd themes/starter
@@ -245,7 +245,7 @@ And add the following to src/scss/main.scss:
 
 You can follow the same process for Javascript files - take a look at the existing components for examples.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 It's generally encouraged to use Sass variables wherever possible. You can find a list of all predefined variables and values in the src/scss/variables.scss file. This file is based on the default Bootstrap 3 variable sheet, with some changes made and some new variables added.
 </div>
 
@@ -263,7 +263,7 @@ npm run package
 
 ## Modifying template files
 
-The starter and Wātea themes are built with the same [template syntax SilverStripe developers are used to](https://docs.silverstripe.org/en/4/developer_guides/templates). Here's what has been changed from the previous "default" theme:
+The CWP Starter and Wātea themes are built with the same [template syntax SilverStripe developers are used to](https://docs.silverstripe.org/en/4/developer_guides/templates). Here's what has been changed from the previous "default" theme:
 
 * Use [Bootstrap 3](http://getbootstrap.com) HTML and CSS, instead of Bootstrap 2
 * Use a new, simplified build chain ([Laravel Mix](https://laravel.com/docs/5.4/mix))
@@ -278,7 +278,7 @@ When you make changes to a template, be sure to flush the site cache (by appendi
 
 In his book [Clean Code](https://www.amazon.com/dp/0132350882), Robert Martin talks about the importance of reading code vs. writing code. That what we write needs to be entirely focused on being easy to read and understand. That writing something succinctly is a waste of time if the effort makes understanding it harder.
 
-That's the main reason that the starter and Wātea themes have opted to use [AirBnB code styles for Javascript]](https://github.com/airbnb/javascript] and  [AirBnB CSS/Sass styleguide](https://github.com/airbnb/css) for Sass and CSS (with a minor adjustment to follow Bootstrap's class naming convention of single dashes rather than BEM). You don't have to use these, in your project, but if you do all of your code will resemble the style used in the Sass and JS theme files.
+That's the main reason that the CWP Starter and Wātea themes have opted to use [AirBnB code styles for Javascript]](https://github.com/airbnb/javascript] and  [AirBnB CSS/Sass styleguide](https://github.com/airbnb/css) for Sass and CSS (with a minor adjustment to follow Bootstrap's class naming convention of single dashes rather than BEM). You don't have to use these, in your project, but if you do all of your code will resemble the style used in the Sass and JS theme files.
 
 ## Javascript linting
 

--- a/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md
+++ b/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md
@@ -31,7 +31,7 @@ make changes to it directly. There are two recommended ways of creating your own
 This will give you a copy of the CWP Starter theme repository that you can edit and can share with others.
 
 1. Browse to the [CWP Starter theme](https://github.com/silverstripe/cwp-starter-theme) in GitHub.
-2. Click on the *Fork* button in the toolbar. This will make a copy of the theme in your GitLab profile.
+2. Click on the *Fork* button in the toolbar. This will make a copy of the theme in your GitHub profile.
 3. Your forked repository has inherited the starter theme's public access. To disable this, go to the settings page.
 (*Settings / Edit Project*) of your repository in Gitlab, change the *Project Visibility* option as required and click *Save*.
 4.  In your theme's `composer.json` file and change the `"name"` parameter to `"my-agency/<theme-name-here>"`.

--- a/docs/en/01_Working_with_projects/06_Working_with_modules.md
+++ b/docs/en/01_Working_with_projects/06_Working_with_modules.md
@@ -44,7 +44,7 @@ requirement):
 }
 ```
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 Please change the module name and namespace. The first part of the "name" in the `composer.json` file constitutes a
 namespace - please use the same namespace that you are using in Gitlab, to distinguish between the officially supported
 CWP modules (that reside in the "cwp" namespace) and private modules.
@@ -61,7 +61,7 @@ Now push your module to the upstream, to the empty repository just created:
 	git remote add origin https://gitlab.cwp.govt.nz/mateusz/foobar.git
 	git push -u origin master
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 If you are pushing to an externally hosted GitHub repository, note that you will need to add the appropriate GitHub remote URL eg:
 </div>
 
@@ -95,7 +95,7 @@ root directory of your main project.
 		}
 	]
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 The `private` parameter is non-standard and is used by Deploynaut to distinguish between private repositories and
 public repositories. See the section below about public modules.
 </div>
@@ -110,7 +110,7 @@ To include a private GitHub hosted module, for our *foobar* module pushed to an 
 		}
 	]
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 The `no-api` parameter prevents API usage which will remove the need for an API token from the CWP deployment systems.
 </div>
 
@@ -130,7 +130,7 @@ we don't need to version-control it through the master repository.
 Run `composer update` to pull the module in and update all other dependencies as well. You can also update just this one
 module by calling `composer update <modulename>`.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 If you get cryptic composer errors it's worth checking that your module code is fully pushed. This is because composer
 can only access the code you have actually pushed to the upstream repository and it may be trying to use the stale
 versions of the files. Also, update composer regularly (`composer self-update`). You can also try deleting Composer
@@ -151,7 +151,7 @@ deploying to, the only thing you need to do is to enable the project key on the 
 key is named after your stack identifier.
 ![Gitlab - private repository deploy access](/_images/gitlab-private-repository-deploy-access.png)
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 You will only see the deployment key if you are the owner of the repository. See [deploying code](deploying-code) for
 more information.
 </div>

--- a/docs/en/01_Working_with_projects/06_Working_with_modules.md
+++ b/docs/en/01_Working_with_projects/06_Working_with_modules.md
@@ -63,9 +63,9 @@ Now push your module to the upstream, to the empty repository just created:
 
 <div class="alert alert-info" markdown='1'>
 If you are pushing to an externally hosted GitHub repository, note that you will need to add the appropriate GitHub remote URL eg:
-</div>
 
-	git remote add origin git@github.com:myprivate/repo.git
+`git remote add origin git@github.com:myprivate/repo.git`
+</div>
 
 Once the module is pushed to the repository you should see the code on Gitlab. From now on it will be available for
 others to clone, as long as they have at least a "Reporter" level access (see the note below though: private modules are
@@ -96,7 +96,7 @@ root directory of your main project.
 	]
 
 <div class="alert alert-info" markdown='1'>
-The `private` parameter is non-standard and is used by Deploynaut to distinguish between private repositories and
+The `private` parameter is non-standard and is used by Dashboard to distinguish between private repositories and
 public repositories. See the section below about public modules.
 </div>
 
@@ -145,7 +145,7 @@ composer](https://docs.silverstripe.org/en/4/getting_started/composer/#deploying
 
 ## Deploying repositories with private modules
 
-If you decide to include private modules in your website project (also your own private repositories), Deploynaut
+If you decide to include private modules in your website project (also your own private repositories), Dashboard
 will need a permission to access them. If you already have your repository associated with the stack you will be
 deploying to, the only thing you need to do is to enable the project key on the module as shown on the image below. The
 key is named after your stack identifier.

--- a/docs/en/01_Working_with_projects/07_Releasing.md
+++ b/docs/en/01_Working_with_projects/07_Releasing.md
@@ -6,7 +6,7 @@ summary: Walkthrough for the deployment of a SilverStripe CMS code onto a CWP se
 A good release practice is to tag a certain Git revision to a version number each time you are doing a release.
 
 This is done by tagging a release from the developer's machine and pushing tags into Gitlab. They will be picked up
-automatically by Deploynaut. To get started, first check which tags are already available:
+automatically by Dashboard. To get started, first check which tags are already available:
 
 	git tag
 

--- a/docs/en/01_Working_with_projects/08_Upgrading.md
+++ b/docs/en/01_Working_with_projects/08_Upgrading.md
@@ -28,7 +28,7 @@ for minor upgrade to take a day of work, and major upgrades could take several d
 To upgrade your code, open the root `composer.json` file (the one that was supplied with the installer). Find the
 lines that reference `cwp-recipe-basic` and `cwp-recipe-basic-dev` and change the referenced versions.
 
-For example assuming that you are currently on version `~1.0.1@stable`, if you wish to upgrade to 1.4.1 you will need to
+For example, assuming that you are currently on version `~1.0.1@stable`, if you wish to upgrade to 1.4.1 you will need to
 modify your `composer.json` file to explicitly specify the new release branch, here `~1.4.1`:
 
 	...
@@ -73,7 +73,7 @@ You will know you need to migrate your project if you see the following configur
 
 This long list of dependencies should no longer be pulled in directly. Here is how to fix this for the future.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 If you have customised the original project based on recipe-basic by removing/changing versions of modules you will
 notice this migration will force you to pull these back via the new cwp-recipe-basic metapackage. This is intended -
 the only code supported by the CWP Team is the mix of modules present in the latest stable release of the
@@ -130,7 +130,7 @@ excluded (as the project already provides its own theme):
 Links:
 
 * [CWP releases and changelogs](/releases_and_changelogs)
-* [old, unsupported composer.json](https://gitlab.cwp.govt.nz/cwp/recipe-basic/blob/1.0.0/composer.json) from
+* [old, unsupported composer.json](https://github.com/silverstripe/cwp-recipe-basic/blob/master/composer.json) from
 deprecated `cwp/recipe-basic` module
 * [new, recommended composer.json](https://github.com/silverstripe/cwp-installer/blob/master/composer.json) from the new
 `cwp/cwp-installer` package (this package is useful for jump-starting your projects)

--- a/docs/en/01_Working_with_projects/08_Upgrading.md
+++ b/docs/en/01_Working_with_projects/08_Upgrading.md
@@ -130,7 +130,7 @@ excluded (as the project already provides its own theme):
 Links:
 
 * [CWP releases and changelogs](/releases_and_changelogs)
-* [old, unsupported composer.json](https://github.com/silverstripe/cwp-recipe-basic/blob/master/composer.json) from
+* [old, unsupported composer.json](https://gitlab.cwp.govt.nz/cwp/recipe-basic/blob/1.0.0/composer.json) from
 deprecated `cwp/recipe-basic` module
 * [new, recommended composer.json](https://github.com/silverstripe/cwp-installer/blob/master/composer.json) from the new
 `cwp/cwp-installer` package (this package is useful for jump-starting your projects)

--- a/docs/en/01_Working_with_projects/10_Security.md
+++ b/docs/en/01_Working_with_projects/10_Security.md
@@ -124,7 +124,7 @@ SilverStripe\Core\Injector\Injector:
 ```
 
 In this case it is necessary to ensure that an SSL certificate has been purchased and configured
-for each domain. If you are unsure, contact the [Service Desk](https://www.cwp.govt.nz/service-desk/).
+for each domain. If you are unsure, contact the [CWP Service Desk](https://www.cwp.govt.nz/service-desk/).
 
 Alternatively, you can completely disable SSL redirection by setting the 
 `CanonicalURLMiddleware.ForceSSL` property to false via Injector configuration (as in the example above),

--- a/docs/en/01_Working_with_projects/11_Infrastructural_considerations.md
+++ b/docs/en/01_Working_with_projects/11_Infrastructural_considerations.md
@@ -8,7 +8,7 @@ summary: Aspects of the CWP server environment infrastructure to be aware of whe
 The high level CWP infrastructure is outlined on cwp.govt.nz.
 More detail is available through a solution architecture document on request
 to participating agencies. See [technical and architecture information](https://www.cwp.govt.nz/about/technical-and-architecture-information/).
-Please review our [Performance Guide](../performance-guide/index)
+Please review our [Performance Guide](/performance-guide/index)
 for recommendations on how to use the available infrastructure efficiently.
 
 ## HTTP request time limit
@@ -21,7 +21,7 @@ has a HTTP request timeout limit of 120 seconds, after which it will
 generate a 504 (Gateway Timeout) error.
 This is preventing overloading of the shared parts of the infrastructure.
 
-<div class="warning" markdown='1'>
+<div class="alert alert-warning" markdown='1'>
 Your publicly accessible URLs should never take a long time to process, as this leaves your environment open to denial of
 service attacks. You should definitely hide these behind a login or a captcha, or use caching and other optimisations
 to bring down the processing time.
@@ -29,9 +29,9 @@ to bring down the processing time.
 
 The preferred way to handle your long-running processes is via the 
 [queuedjobs](https://github.com/symbiote/silverstripe-queuedjobs) module. 
-You can extend the time limit of a PHP process is to use the SilverStripe Framework APIs `increase_time_limit_to`.
+You can extend the time limit of a PHP process by using the SilverStripe Framework APIs `increase_time_limit_to`.
 
-Consider using [caching](../performance-guide/caching) to speed up request execution.
+Consider using [caching](/performance-guide/caching) to speed up request execution.
 
 ## PHP configuration
 
@@ -41,12 +41,12 @@ The default `memory_limit` configuration is 128 MB. You can increase this to 256
 with `ini_set('memory_limit', '256M');` in your code.
 Please call this on a per-script basis. Increasing the limit for all requests increases the likelihood of server instability with high traffic.
 If you have a script which requires more than 256 MB, we typically recommend making it a task, runnable from a cron job on a schedule.
-Please raise a ticket via [Service Desk](https://www.cwp.govt.nz/service-desk) for help with this.
+Please raise a ticket via the [CWP Service Desk](https://www.cwp.govt.nz/service-desk) for help with this.
 
 ## PHP extensions
 
 Environments within a CWP stack are turnkey deployments of a standardised environment. For security and
-supportability reasons we do not allow the installation of binaries, PHP extensions or other deviations from the
+supportability reasons we don't allow the installation of binaries, PHP extensions or other deviations from the
 standard environment that are not encapsulated within the PHP code deployed into the environment.
 
 These PHP extensions are part of the standard environment, and can be relied on to be available:
@@ -60,7 +60,7 @@ These PHP extensions are part of the standard environment, and can be relied on 
 ## Webserver
 
 CWP environments are running Apache 2.4 (see Debian "Jessie" [packages](https://packages.debian.org/jessie/)).
-Note that there's other [caching infrastructure](/how_tos/caching) in front of CWP environment.
+Note that there's other [caching infrastructure](../../performance_guide/caching) in front of CWP environment.
 
 ## Database
 
@@ -69,7 +69,7 @@ For local development, you can also choose MySQL 5.6.
 
 ## Hosting video
 
-CWP stacks do not provide built in hosting of video content, and we recommend you do not attempt to do so.
+CWP stacks don't provide built in hosting of video content, and we recommend you don't attempt to do so.
 
 Instead, we recommend hosting video on a third-party service, such as vimeo.com. They provide a simple, turn-key
 solution optimised for hosting video that is easily integrated with CWP environments.
@@ -84,14 +84,14 @@ sufficient bandwidth for hosting. You will also need to provide your own solutio
 such as:
 
 1. Transcoding the video to the variety of formats needed by different web-enabled devices
-1. A player that provides the necessary controls and accessibility extensions to the devices built-in video playing
+2. A player that provides the necessary controls and accessibility extensions to the devices' built-in video playing
 support
 
 ## Other features
 
- * [Varnish and Incapsula caching](how_tos/caching)
+ * [Varnish and Incapsula caching](/performance_guide/http_caching)
  * [Outgoing HTTP proxy](/how_tos/external_http_requests_with_proxy)
- * [WKHTMLTOPDF](http://wkhtmltopdf.org/) is available in version 0.12.1.1.
+ * [WKHTMLTOPDF](http://wkhtmltopdf.org/) is available in series 0.12.4.
  * [Solr search](/features/solr_search)
  * [Apache Tika](/features/solr_search/searching_documents)
 
@@ -102,5 +102,5 @@ options available:
 
 * Wrapping of the feature as a web application hosted outside the CWP infrastructure (either at your own cost or
 through an external provider)
-* Integration of feature as a CWP standard feature, either through directly funded work or through the co-fund pool
+* Integration of the feature as a CWP standard feature, either through directly funded work or through the co-fund pool
 (we are unlikely to accept requests to integrate features that duplicate functionality already present within CWP)

--- a/docs/en/01_Working_with_projects/11_Infrastructural_considerations.md
+++ b/docs/en/01_Working_with_projects/11_Infrastructural_considerations.md
@@ -29,7 +29,7 @@ to bring down the processing time.
 
 The preferred way to handle your long-running processes is via the 
 [queuedjobs](https://github.com/symbiote/silverstripe-queuedjobs) module. 
-You can extend the time limit of a PHP process by using the SilverStripe Framework APIs `increase_time_limit_to`.
+You can extend the time limit of a PHP process by using the SilverStripe Framework APIs `\SilverStripe\Core\Environment::increaseTimeLimitTo()`.
 
 Consider using [caching](/performance-guide/caching) to speed up request execution.
 
@@ -60,7 +60,7 @@ These PHP extensions are part of the standard environment, and can be relied on 
 ## Webserver
 
 CWP environments are running Apache 2.4 (see Debian "Jessie" [packages](https://packages.debian.org/jessie/)).
-Note that there's other [caching infrastructure](../../performance_guide/caching) in front of CWP environment.
+Note that there's other [caching infrastructure](/performance_guide/caching) in front of your CWP environment.
 
 ## Database
 
@@ -69,7 +69,7 @@ For local development, you can also choose MySQL 5.6.
 
 ## Hosting video
 
-CWP stacks don't provide built in hosting of video content, and we recommend you don't attempt to do so.
+CWP stacks don't provide built-in hosting of video content, and we recommend you don't attempt to do so.
 
 Instead, we recommend hosting video on a third-party service, such as vimeo.com. They provide a simple, turn-key
 solution optimised for hosting video that is easily integrated with CWP environments.

--- a/docs/en/01_Working_with_projects/12_CWP_environment_variables.md
+++ b/docs/en/01_Working_with_projects/12_CWP_environment_variables.md
@@ -6,7 +6,7 @@ introduction: Describes the environment variables present on CWP environments.
 
 ## Available environment variables (PHP constants)
 
-The following [SilverStripe CMS constants and globals](https://docs.silverstripe.org/en/3.2/getting_started/environment_management/)
+The following [SilverStripe CMS constants and globals](https://docs.silverstripe.org/en/4/getting_started/environment_management/)
 are set by default on CWP environments.
 
 |Constant/Global|Guaranteed value|

--- a/docs/en/01_Working_with_projects/13_Centralised_logging.md
+++ b/docs/en/01_Working_with_projects/13_Centralised_logging.md
@@ -59,7 +59,7 @@ CWP environments will automatically write several log types which can be searche
 long as the project includes the `cwp-core` module.
 
 * `SilverStripe_log`: standard log output of the Framework, will capture all events occurring after successful Framework
-bootstrap. This includes uncaught exceptions and any `SS_Log::log` events.
+bootstrap. This includes uncaught exceptions and any `Injector::inst()->get(LoggerInterface::class)->...` events.
 * `SilverStripe_audit`: audit trail of security-related events provided by the *silverstripe/auditor* module.
 * `apache`: apache access logs.
 * `apache-errors`: errors reported by Apache, which could include `mod_php` segmentation faults.
@@ -109,7 +109,12 @@ The recipes are configured to send all logs to syslog, which are then accessible
 to log events on CWP is through the `SS_Log` API:
 
 ```php
-SS_Log::log('Something seems to have happened', SS_Log::NOTICE);
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Injector\Injector;
+
+// ...
+
+Injector::inst()->get(LoggerInterface::class)->notice('Something seems to have happened');
 ```
 
 For more information on general usage of the Framework's logging subsystem, see

--- a/docs/en/01_Working_with_projects/13_Centralised_logging.md
+++ b/docs/en/01_Working_with_projects/13_Centralised_logging.md
@@ -10,23 +10,16 @@ centralised installation of Graylog.
 You can access Graylog using your CWP log-in at the following URL:
 [https://logs.cwp.govt.nz/](https://logs.cwp.govt.nz/).
 
-In order to gain access to these logs please raise a general support request with the [CWP service desk](https://www.cwp.govt.nz/service-desk/new-request/).
+In order to gain access to these logs please raise a general support request with the [CWP Service Desk](https://www.cwp.govt.nz/service-desk/new-request/).
 
 We provide a stream for each environment. Streams are where
 you can view and query the stored logs. These include Apache, PHP, and any
 custom events that you want to log.
 
-<div class="notice" markdown='1'>
-`SS_SysLogWriter` use is now deprecated on CWP, because it could interfere with Graylog operation and could
-[cause side-effects](https://github.com/silverstripe/silverstripe-auditor#warning-do-not-use-ss_syslogwriter)
-with the audit logger. [Adding other writers](/how_tos/error_logging/) is fine.
-</div>
-
 ## Searching
 
-Each search requires a time period to search (default is last 5 minutes) and
-query string. The query string uses Graylog's query syntax which you can find
-more about by reading [Graylog documentation](http://docs.graylog.org/en/latest/pages/queries.html).
+Each search requires a time period to search and
+query strings (the default is 5 minutes). The query string uses Graylog's query syntax which you can find out more about by reading [Graylog documentation](http://docs.graylog.org/en/latest/pages/queries.html).
 
 To get you started with Graylog there are some predefined searches you can
 select from the top right corner. These are:
@@ -65,7 +58,7 @@ Following are a couple of examples on search queries:
 CWP environments will automatically write several log types which can be searched with the `log_type` keyword in Graylog, as
 long as the project includes the `cwp-core` module.
 
-* `SilverStripe_log`: standard log output of the Framework, will capture all events occuring after successful Framework
+* `SilverStripe_log`: standard log output of the Framework, will capture all events occurring after successful Framework
 bootstrap. This includes uncaught exceptions and any `SS_Log::log` events.
 * `SilverStripe_audit`: audit trail of security-related events provided by the *silverstripe/auditor* module.
 * `apache`: apache access logs.
@@ -81,10 +74,10 @@ on the button of the analysis you want to perform.
 
 ### Field statistics
 
-You can compute different statistics on your fields, to help you better summarize and 
+You can compute different statistics on your fields, to help you better summarise and 
 understand the data in them.
 
-The statistical information consist of: total, mean, minimum, maximum, standard
+The statistical information consists of: total, mean, minimum, maximum, standard
 deviation, variance, sum, and cardinality. On non-numeric fields, you can only
 see the total amount of messages containing that field, and the cardinality of
 the field, i.e. the number of unique values it has.
@@ -108,11 +101,11 @@ interpolation, as well as the time resolution.
 
 ![field graphs](/_images/logs/field_graph.png)
 
-For more information see [Graylog analysis documentation](http://docs.graylog.org/en/1.2/pages/queries.html#analysis).
+For more information see [Graylog analysis documentation](http://docs.graylog.org/en/stable/pages/queries.html#analysis).
 
 ## Logging custom events
 
-Basic recipe is configured to send all logs to syslog, which are then accessible through Graylog. The recommended way
+The recipes are configured to send all logs to syslog, which are then accessible through Graylog. The recommended way
 to log events on CWP is through the `SS_Log` API:
 
 ```php
@@ -120,7 +113,7 @@ SS_Log::log('Something seems to have happened', SS_Log::NOTICE);
 ```
 
 For more information on general usage of the Framework's logging subsystem, see
-[logging in SilverStripe documentation](https://docs.silverstripe.org/en/3.1/developer_guides/debugging/error_handling/).
+the [logging in SilverStripe documentation](https://docs.silverstripe.org/en/4/developer_guides/debugging/error_handling/).
 
 ## Custom audit trail
 

--- a/docs/en/01_Working_with_projects/13_Centralised_logging.md
+++ b/docs/en/01_Working_with_projects/13_Centralised_logging.md
@@ -106,7 +106,7 @@ For more information see [Graylog analysis documentation](http://docs.graylog.or
 ## Logging custom events
 
 The recipes are configured to send all logs to syslog, which are then accessible through Graylog. The recommended way
-to log events on CWP is through the `SS_Log` API:
+to log events on CWP is through the SilverStripe logging API:
 
 ```php
 use Psr\Log\LoggerInterface;

--- a/docs/en/01_Working_with_projects/14_Using_the_Watea_theme.md
+++ b/docs/en/01_Working_with_projects/14_Using_the_Watea_theme.md
@@ -4,7 +4,7 @@ introduction: Describes how to use the CWP Wātea theme
 
 # Using the Wātea theme
 
-[The Wātea theme](https://gitlab.cwp.govt.nz/cwp/watea-theme) is a more "designed" [subtheme](https://docs.silverstripe.org/en/3/developer_guides/templates/themes) which can be installed over the top of the [Starter theme](customising_the_starter_theme) to provide a more visually appealing starter project.
+[The Wātea theme](https://github.com/silverstripe/cwp-watea-theme) is a more "designed" [subtheme](https://docs.silverstripe.org/en/4/developer_guides/templates/themes) which can be installed over the top of the [CWP Starter theme](customising_the_starter_theme) to provide a more visually appealing starter project.
 
 ## Installation
 
@@ -14,30 +14,29 @@ Install this theme module with Composer:
 composer require cwp/watea-theme
 ```
 
-This will also install the following dependencies:
+This will also install the `cwp/starter-theme` dependency, which is the foundation for this subtheme. 
 
-* `cwp/starter-theme`: The foundation for this subtheme
-* `cwp/agency-extensions`: Provides additional functionality to the CMS for agency-style SilverStripe websites
+The installation of `cwp/agency-extensions` is suggested as it provides additional functionality to the CMS for agency-style SilverStripe websites.
 
 ## Getting started
 
-This theme is designed to augment the base functionality and framework provided by the [Starter theme](https://gitlab.cwp.govt.nz/cwp/starter-theme). As such, [all of the documentation for the Starter theme](customising_the_starter_theme) is relevant to this theme as well. We suggest you familiarise yourself with this documentation.
+This theme is designed to augment the base functionality and framework provided by the [CWP Starter theme](https://github.com/silverstripe/cwp-starter-theme). As such, [all of the documentation for the CWP Starter theme](customising_the_starter_theme) is relevant to this theme as well. We suggest you familiarise yourself with this documentation.
 
-As a general rule, CWP Team have endeavoured to constrain changes for this subtheme to CSS and Javascript wherever possible, as opposed to modifying and duplicating the templates. As a subtheme, all templates in this theme will be applied over the top (with priority) of the Starter theme, and will be available to the SilverStripe template manifest under the "starter" theme name. You will not see the Wātea theme in theme selectors, etc.
+As a general rule, the CWP Team have endeavoured to constrain changes for this subtheme to CSS and Javascript wherever possible, as opposed to modifying and duplicating the templates. As a subtheme, all templates in this theme will be applied over the top (with priority) of the CWP Starter theme, and will be available to the SilverStripe template manifest under the "starter" theme name. You will not see the Wātea theme in theme selectors, etc.
 
 If you need to modify template markup from the SilverStripe framework, other modules or even the Starter theme, you can copy them into the "starter_watea" subtheme directory and modify them there.
 
 ## Development
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 Please familiarise yourself with [Customising the starter theme](customising_the_starter_theme), as all documentation there is relevant for this subtheme as well.
 </div>
 
 ### Setup
 
-For development you will need Node and NPM installed. Please see the [Customising the starter theme](customising_the_starter_theme) article for more information.
+For development you will need Node.js and npm installed. Please see the [Customising the starter theme](customising_the_starter_theme) article for more information.
 
-Next, you need to install the required NPM packages. You will need to do this both in the "starter" theme and in the "starter_watea" subtheme, as this subtheme imports components from the "starter" theme during Sass building. Ensure you have changed each theme's directory first:
+Next, you need to install the required npm packages. You will need to do this both in the CWP Starter theme and in the "starter_watea" subtheme, as this subtheme imports components from the "starter" theme during Sass building. Ensure you have changed each theme's directory first:
 
 ```
 cd themes/starter
@@ -46,15 +45,9 @@ cd ../starter_watea
 npm install
 ```
 
-### Backend changes
-
-This theme and the base-theme also come with the [`cwp/agency-extensions` module](https://gitlab.cwp.govt.nz/cwp/agency-extensions) which helps us to clean up some parts of the CMS, rename some settings fields and provide a little bit of extra functionality to help the Wātea theme work.
-
-If you need to extend or modify these changes at all, you can control the theme's extensions with YAML configuration, or create your own extensions in your `mysite` code.
-
 ### Compiling assets
 
-Similarly to the Starter theme, you can compile assets using NPM commands:
+Similarly to the CWP Starter theme, you can compile assets using npm commands:
 
 ```
 npm run build   # Produces unminified (development) distributable files in dist/
@@ -66,12 +59,13 @@ Or to "watch" for changes in real time as you develop (faster):
 ```
 npm run watch  # Compiles as "build", then watches for changes and recompiles as necessary
 ```
+<div class="alert alert-info" markdown='1'>
+Please note: This subtheme's compiled Javascript assets are only relevant to this theme, and should be applied on top of the CWP Starter theme's assets. Ensure that you include them in the correct order.
+</div>
 
-**Please note:** This subtheme's compiled Javascript assets are only relevant to this theme, and should be applied on top of the Starter theme's assets. Ensure that you include them in the correct order.
+For CSS, this theme contains _a fully compiled_ set of styles for both themes. You should only include this theme's CSS (not the CWP Starter theme).
 
-For CSS, this theme contains _a fully compiled_ set of styles for both themes. You should only include this theme's CSS (not the Starter theme).
-
-To be able to "npm run build" in the Wātea theme, you will also be required to have run "npm install" in the Starter theme.
+To be able to "npm run build" in the Wātea theme, you will also be required to have run "npm install" in the CWP Starter theme.
 
 For example:
 
@@ -93,4 +87,4 @@ npm run lint-js
 npm run lint-sass
 ```
 
-For information on the rules and configuration around these linters, please see the [Starter theme](customising_the_starter_theme) documentation regarding "working with standards".
+For information on the rules and configuration around these linters, please see the [CWP Starter theme](customising_the_starter_theme) documentation regarding "working with standards".

--- a/docs/en/01_Working_with_projects/14_Using_the_Watea_theme.md
+++ b/docs/en/01_Working_with_projects/14_Using_the_Watea_theme.md
@@ -4,7 +4,7 @@ introduction: Describes how to use the CWP Wātea theme
 
 # Using the Wātea theme
 
-[The Wātea theme](https://github.com/silverstripe/cwp-watea-theme) is a more "designed" [subtheme](https://docs.silverstripe.org/en/4/developer_guides/templates/themes) which can be installed over the top of the [CWP Starter theme](customising_the_starter_theme) to provide a more visually appealing starter project.
+[The Wātea theme](https://github.com/silverstripe/cwp-watea-theme) is a more "designed" [cascading theme](https://docs.silverstripe.org/en/4/developer_guides/templates/themes) which can be installed over the top of the [CWP Starter theme](customising_the_starter_theme) to provide a more visually appealing starter project.
 
 ## Installation
 
@@ -22,7 +22,9 @@ The installation of `cwp/agency-extensions` is suggested as it provides addition
 
 This theme is designed to augment the base functionality and framework provided by the [CWP Starter theme](https://github.com/silverstripe/cwp-starter-theme). As such, [all of the documentation for the CWP Starter theme](customising_the_starter_theme) is relevant to this theme as well. We suggest you familiarise yourself with this documentation.
 
-As a general rule, the CWP Team have endeavoured to constrain changes for this subtheme to CSS and Javascript wherever possible, as opposed to modifying and duplicating the templates. As a subtheme, all templates in this theme will be applied over the top (with priority) of the CWP Starter theme, and will be available to the SilverStripe template manifest under the "starter" theme name. You will not see the Wātea theme in theme selectors, etc.
+As a general rule, the CWP Team have endeavoured to constrain changes for this theme to CSS and Javascript wherever 
+possible, as opposed to modifying and duplicating the templates. As a cascading theme, all templates in this theme will 
+be applied over the top (with priority) of the CWP Starter theme.
 
 If you need to modify template markup from the SilverStripe framework, other modules or even the Starter theme, you can copy them into the "starter_watea" subtheme directory and modify them there.
 
@@ -71,11 +73,11 @@ For example:
 
 ```
 # File: templates/Page.ss - in the <head>
-<link rel="stylesheet" href="$ThemeDir(watea)/dist/css/main.css">
+<% require themedCss('dist/css/main.css') %>
 
 # File: templates/Page.ss - near the bottom of the <body>
-<script src="{$ThemeDir}/dist/js/main.js"></script>
-<script src="$ThemeDir(watea)/dist/js/main.js"></script>
+<% require javascript('themes/starter/dist/js/main.js') %>
+<% require javascript('themes/watea/dist/js/main.js') %>
 ```
 
 ### Linting

--- a/docs/en/02_Features/00_Pre_configuration.md
+++ b/docs/en/02_Features/00_Pre_configuration.md
@@ -1,29 +1,29 @@
 title: Pre-configuration of CWP recipe codebase
 summary: Sets out what has been pre-configured in the SilverStripe core and modules when using the CWP recipe.
-introduction: The CWP recipe codebase includes two modules that pre-configure your SilverStripe CMS website in order to operate correctly on the CWP infrastructure. Developers should be aware where these settings originate and what can or cannot be customised to ensure websites function correctly on CWP.  
+introduction: The CWP recipe codebase includes two modules that pre-configure your SilverStripe CMS website in order to operate correctly on the CWP infrastructure. Developers should be aware where these settings originate and what can or can't be customised to ensure websites function correctly on CWP.  
 
 # Pre-configuration of CWP recipe codebase
 
-The default SilverStripe CMS codebase used on the CWP infrastructure is referred to as the ["basic recipe"](../working_with_projects/recipes_and_supported_modules).
+The default SilverStripe CMS codebase used on the CWP infrastructure is referred to as the ["basic recipe"](/working_with_projects/recipes_and_supported_modules).
 When starting a new CWP project based on the [`cwp/cwp-installer`](/getting_started) custom SilverStripe CMS installer for CWP, a
 selection of pre-configured modules are included (we've done the work for you as you would usually have to configure
 these modules yourself) and provide a set of standardised features for Government agencies. Some of this
 configuration is mandatory in order for your website to operate correctly on the CWP servers, while others
 are able to be altered depending on your project needs.
 
-Modules and configuration are added on the top of the SilverStripe CMS core through the use of the [Composer](https://docs.silverstripe.org/en/3.2/getting_started/composer/)
-PHP package management tool. By including the [`cwp/cwp-recipe-basic`](https://gitlab.cwp.govt.nz/cwp/cwp-recipe-basic/blob/master/composer.json) module in your projects `composer.json`
+Modules and configuration are added on the top of the SilverStripe CMS core through the use of the [Composer](https://docs.silverstripe.org/en/4/getting_started/composer/)
+PHP package management tool. By including the [`cwp/cwp-recipe-basic`](https://github.com/silverstripe/cwp-recipe-basic/blob/master/composer.json) module in your projects `composer.json`
 file, the modules that make up the "recipe" are then added to the project.
 
 This includes two CWP specific modules and some default SilverStripe CMS project code (in the `mysite` directory)
-that use the [Configuration API](https://docs.silverstripe.org/en/3.2/developer_guides/configuration/configuration/)
+that use the [Configuration API](https://docs.silverstripe.org/en/4/developer_guides/configuration/configuration/)
 and PHP code to manage the majority of the CWP pre-configuration:
 
-  * [cwp/cwp-core](https://gitlab.cwp.govt.nz/cwp/cwp-core) (\*mandatory, must be included) - Pre-configures Solr configuration and indexing, logging, environment checks and
+  * [cwp/cwp-core](https://github.com/silverstripe/cwp-core) (\*mandatory, must be included) - Pre-configures Solr configuration and indexing, logging, environment checks and
   other shared service configuration.
-  * [cwp/cwp](https://gitlab.cwp.govt.nz/cwp/cwp) (\*optional, but recommended) - Includes many of the custom features for CWP (new page types etc)
+  * [cwp/cwp](https://github.com/silverstripe/cwp) (\*optional, but recommended) - Includes many of the custom features for CWP (new page types etc)
   and pre-configures search results (optional boosting and synonyms) and several recipe included modules.
-  * [mysite/_config/config.yml](https://gitlab.cwp.govt.nz/cwp/cwp-installer/blob/1.2.0/mysite/_config/config.yml) (\*mandatory, but part of your project and customisable) - The `cwp/cwp-installer` includes some
+  * [mysite/_config/config.yml](https://github.com/silverstripe/cwp-installer/blob/1.2.0/mysite/_config/config.yml) (\*mandatory, but part of your project and customisable) - The `cwp/cwp-installer` includes some
   pre-configured options that you may customise (the defaults will work with CWP out of the box).
-  * [mysite/_config/blog.yml](https://gitlab.cwp.govt.nz/cwp/cwp-installer/blob/1.2.0/mysite/_config/blog.yml) (\*optional, if using blogging feature on CWP) - Pre-configures a set of blogging features when using 
+  * [mysite/_config/blog.yml](https://github.com/silverstripe/cwp-installer/blob/1.2.0/mysite/_config/blog.yml) (\*optional, if using blogging feature on CWP) - Pre-configures a set of blogging features when using 
   the optional "blogging recipe" (see [Blogging developer docs](blog_recipe)).

--- a/docs/en/02_Features/00_Pre_configuration.md
+++ b/docs/en/02_Features/00_Pre_configuration.md
@@ -4,7 +4,7 @@ introduction: The CWP recipe codebase includes two modules that pre-configure yo
 
 # Pre-configuration of CWP recipe codebase
 
-The default SilverStripe CMS codebase used on the CWP infrastructure is referred to as the ["basic recipe"](/working_with_projects/recipes_and_supported_modules).
+The default SilverStripe CMS codebase used on the CWP infrastructure is referred to as the ["CWP CMS recipe"](/working_with_projects/recipes_and_supported_modules).
 When starting a new CWP project based on the [`cwp/cwp-installer`](/getting_started) custom SilverStripe CMS installer for CWP, a
 selection of pre-configured modules are included (we've done the work for you as you would usually have to configure
 these modules yourself) and provide a set of standardised features for Government agencies. Some of this
@@ -12,7 +12,7 @@ configuration is mandatory in order for your website to operate correctly on the
 are able to be altered depending on your project needs.
 
 Modules and configuration are added on the top of the SilverStripe CMS core through the use of the [Composer](https://docs.silverstripe.org/en/4/getting_started/composer/)
-PHP package management tool. By including the [`cwp/cwp-recipe-basic`](https://github.com/silverstripe/cwp-recipe-basic/blob/master/composer.json) module in your projects `composer.json`
+PHP package management tool. By including the [`cwp/cwp-recipe-cms`](https://github.com/silverstripe/cwp-recipe-cms/blob/master/composer.json) module in your projects `composer.json`
 file, the modules that make up the "recipe" are then added to the project.
 
 This includes two CWP specific modules and some default SilverStripe CMS project code (in the `mysite` directory)
@@ -23,7 +23,7 @@ and PHP code to manage the majority of the CWP pre-configuration:
   other shared service configuration.
   * [cwp/cwp](https://github.com/silverstripe/cwp) (\*optional, but recommended) - Includes many of the custom features for CWP (new page types etc)
   and pre-configures search results (optional boosting and synonyms) and several recipe included modules.
-  * [mysite/_config/config.yml](https://github.com/silverstripe/cwp-installer/blob/1.2.0/mysite/_config/config.yml) (\*mandatory, but part of your project and customisable) - The `cwp/cwp-installer` includes some
+  * [mysite/_config/config.yml](https://github.com/silverstripe/recipe-core/blob/1.1/mysite/_config/mysite.yml) (\*mandatory, but part of your project and customisable) - The `cwp/cwp-installer` includes some
   pre-configured options that you may customise (the defaults will work with CWP out of the box).
-  * [mysite/_config/blog.yml](https://github.com/silverstripe/cwp-installer/blob/1.2.0/mysite/_config/blog.yml) (\*optional, if using blogging feature on CWP) - Pre-configures a set of blogging features when using 
+  * [mysite/_config/blog.yml](https://github.com/silverstripe/recipe-blog/blob/master/mysite/_config/blog.yml) (\*optional, if using blogging feature on CWP) - Pre-configures a set of blogging features when using 
   the optional "blogging recipe" (see [Blogging developer docs](blog_recipe)).

--- a/docs/en/02_Features/01_Solr_search/00_Configuration.md
+++ b/docs/en/02_Features/01_Solr_search/00_Configuration.md
@@ -8,11 +8,11 @@ summary: How Solr is pre-configured for CWP and what you can alter.
 You must satisfy the following requirements to successfully connect to the shared CWP Solr service:
 
 * If you are starting a new project, best compatibility is achieved by using the [cwp-installer](https://github.com/silverstripe/cwp-installer).
-* If it's an existing project, you should include the [cwp-recipe-basic](https://github.com/silverstripe/cwp/cwp-recipe-basic) for the ease of integration. Although we don't recommend it, with extra work you can get it working by only including the [cwp-core](https://gitlab.cwp.govt.nz/cwp/cwp-core/) module.
+* If it's an existing project, you should include the [cwp-recipe-basic](https://github.com/silverstripe/cwp/cwp-recipe-basic) for the ease of integration. Although we don't recommend it, with extra work you can get it working by only including the [cwp-core](https://github.com/silverstripe/cwp) module.
 
 ## Selecting Solr version
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 As of 28/09/2016 'legacy' and 'cwp-3' versions are not supported on CWP anymore.
 </div>
 

--- a/docs/en/02_Features/01_Solr_search/00_Configuration.md
+++ b/docs/en/02_Features/01_Solr_search/00_Configuration.md
@@ -8,7 +8,7 @@ summary: How Solr is pre-configured for CWP and what you can alter.
 You must satisfy the following requirements to successfully connect to the shared CWP Solr service:
 
 * If you are starting a new project, best compatibility is achieved by using the [cwp-installer](https://github.com/silverstripe/cwp-installer).
-* If it's an existing project, you should include the [cwp-recipe-basic](https://github.com/silverstripe/cwp/cwp-recipe-basic) for the ease of integration. Although we don't recommend it, with extra work you can get it working by only including the [cwp-core](https://github.com/silverstripe/cwp) module.
+* If it's an existing project, you should include the [cwp/cwp-recipe-cms](https://github.com/silverstripe/cwp-recipe-cms) for the ease of integration. Although we don't recommend it, with extra work you can get it working by only including the [cwp-core](https://github.com/silverstripe/cwp) module.
 
 ## Selecting Solr version
 

--- a/docs/en/02_Features/01_Solr_search/01_Running_solr_locally.md
+++ b/docs/en/02_Features/01_Solr_search/01_Running_solr_locally.md
@@ -8,7 +8,7 @@ dependency in your top-level `composer.json` file.
 
 When selecting versions, make sure you use the version supported by CWP: `4.*@dev`.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 Older versions of *silverstripe-fulltextsearch* module used to bundle the Solr binary. You should check the version of this module before proceeding with this guide.
 </div>
 

--- a/docs/en/02_Features/01_Solr_search/04_Default_search_index.md
+++ b/docs/en/02_Features/01_Solr_search/04_Default_search_index.md
@@ -39,6 +39,6 @@ Please note that if you want to index other database fields or need to create a 
 *Note:* The line `$this->addFilterField('ShowInSearch');` is a standard requirement for all CWP recipe versions, and will need to be added to any custom indexes created.
 
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 If you are using cwp recipe 1.1.0 or below please refer to [version 1.1 and before documentation archive](https://www.cwp.govt.nz/developer-docs/en/1.1/features/solr_search#default-search-index-2) for the index code
 </div>

--- a/docs/en/02_Features/01_Solr_search/05_Searching_dataobjects.md
+++ b/docs/en/02_Features/01_Solr_search/05_Searching_dataobjects.md
@@ -66,7 +66,7 @@ class MySolrSearchIndex extends CwpSearchIndex
 }
 ```
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 If you are using cwp recipe 1.1.0 or below please refer to the [version 1.1 and before documentation archive](https://www.cwp.govt.nz/developer-docs/en/1.1/features/solr_search#adding-dataobject-classes-to-solr-search-2) for the index code
 </div>
 

--- a/docs/en/02_Features/01_Solr_search/07_Searching_documents.md
+++ b/docs/en/02_Features/01_Solr_search/07_Searching_documents.md
@@ -3,7 +3,7 @@ summary: How to configure Solr indexing and searching of documentation such as W
 
 # Searching within documents
 
-<div class="notice" markdown='1'>This feature requires cwp recipe 1.1.0 or above specifically the [textextraction](https://github.com/silverstripe-labs/silverstripe-textextraction) module</div>
+<div class="alert alert-info" markdown='1'>This feature requires cwp recipe 1.1.0 or above specifically the [textextraction](https://github.com/silverstripe-labs/silverstripe-textextraction) module</div>
 
 By default all CWP environments have text extraction services configured. These services can be used by user code
 to transform text-based documents (such as PDF, MS Word, or rich text) into plain text in a format which can

--- a/docs/en/02_Features/active_directory_single_sign_on.md
+++ b/docs/en/02_Features/active_directory_single_sign_on.md
@@ -11,8 +11,8 @@ further prompts when they switch applications.
 
 ## Introduction
 
-Single sign-on is provided by the open sourced
-module [SilverStripe Active Directory](https://github.com/silverstripe/silverstripe-activedirectory).
+Single sign-on is provided by the open sourced module 
+[SilverStripe Active Directory](https://github.com/silverstripe/silverstripe-activedirectory).
 
 This module allows users of a CWP intranet site to seamlessly login once and never be prompted to login to the site again.
 

--- a/docs/en/02_Features/active_directory_single_sign_on.md
+++ b/docs/en/02_Features/active_directory_single_sign_on.md
@@ -11,7 +11,7 @@ further prompts when they switch applications.
 
 ## Introduction
 
-Single Sign-on is provided by the open sourced
+Single sign-on is provided by the open sourced
 module [SilverStripe Active Directory](https://github.com/silverstripe/silverstripe-activedirectory).
 
 This module allows users of a CWP intranet site to seamlessly login once and never be prompted to login to the site again.
@@ -50,7 +50,7 @@ The idea is that a user can open their browser, go to the
 intranet site and be automatically logged in with their already
 authenticated Windows user.
 
-This Single Sign-on solution is "opinionated", which means it has
+This single sign-on solution is "opinionated", which means it has
 very firm ideas about how things ought to be done. The solution
 tightly couples a set of services to provide the best user
 experience and therefore the requirements are strict.
@@ -100,22 +100,23 @@ To be able to use them on a CWP site you will override the default
 with the following in `mysite/_config.php`
 
 **Replace 'stackname' with the actual stack name so that the URL is correct.**
-
-	// Configure SAML certificates for the CWP UAT environment
-	if(defined('CWP_ENVIRONMENT') && (CWP_ENVIRONMENT == 'uat' || CWP_ENVIRONMENT == 'uatdr')) {
-	    Config::inst()->update('SAMLConfiguration', 'SP', array(
-	        'entityId' => 'https://stackname-uat.cwp.govt.nz/',
-	        'privateKey' => '../../certs/saml.pem',
-	        'x509cert' => '../../certs/saml.crt'
-	    ));
-	// Configure SAML certificates for the CWP Production environment
-	} elseif(defined('CWP_ENVIRONMENT') && (CWP_ENVIRONMENT == 'prod' || CWP_ENVIRONMENT == 'dr')) {
-	    Config::inst()->update('SAMLConfiguration', 'SP', array(
-	        'entityId' => 'https://stackname.cwp.govt.nz/',
-	        'privateKey' => '../../certs/saml.pem',
-	        'x509cert' => '../../certs/saml.crt'
-	    ));
-	}
+```php
+// Configure SAML certificates for the CWP UAT environment
+if(defined('CWP_ENVIRONMENT') && (CWP_ENVIRONMENT == 'uat' || CWP_ENVIRONMENT == 'uatdr')) {
+    Config::inst()->update('SAMLConfiguration', 'SP', [
+        'entityId' => 'https://stackname-uat.cwp.govt.nz/',
+        'privateKey' => '../../certs/saml.pem',
+        'x509cert' => '../../certs/saml.crt'
+    ]);
+// Configure SAML certificates for the CWP Production environment
+} elseif(defined('CWP_ENVIRONMENT') && (CWP_ENVIRONMENT == 'prod' || CWP_ENVIRONMENT == 'dr')) {
+    Config::inst()->update('SAMLConfiguration', 'SP', [
+        'entityId' => 'https://stackname.cwp.govt.nz/',
+        'privateKey' => '../../certs/saml.pem',
+        'x509cert' => '../../certs/saml.crt'
+    ]);
+}
+```
 	
 ### Disable the basic auth for an intranet site
 
@@ -159,7 +160,7 @@ The ADFS will step in as a web endpoint on a secure HTTPS
 connection that uses the DC as a Identity Provider.
 
 Mobile devices often can't provide IWA details so that would
-prevent Single Sign-on for mobile devices.
+prevent Single sign-on for mobile devices.
 
 Since ADFS is exposed as a website it can automatically login users
 if their device support IWA or can fall back to a standard login

--- a/docs/en/02_Features/blog_recipe.md
+++ b/docs/en/02_Features/blog_recipe.md
@@ -7,15 +7,15 @@ The SilverStripe blog module lets you publish blog posts and allow the public to
 engage with you by commenting on your posts. The module supports flexible
 categorisation and tagging of blog posts.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 From 1.1.0 onwards the `blog recipe` is included along side the basic recipe by default.
 </div>
 
-[Three levels of permissions are supported](https://github.com/silverstripe/silverstripe-blog/blob/master/docs/en/roles.md):
+[Three levels of permissions are supported](https://github.com/silverstripe/silverstripe-blog/blob/master/docs/en/userguide/roles.md):
 
  * Editors who can control everything in their blog
  * Writers who can create and publish in their blog
- * Contributors who can write, but have limited permissions otherwise.
+ * Contributors who can write, but have limited permissions otherwise
 
 Commenting can be enabled and disabled, and all comments go through a
 [spam filter](/how_tos/akismet) and then need to be manually moderated before
@@ -30,15 +30,15 @@ subscribe to your blog posts.
 
 This recipe includes the following modules:
 
+ * [Akismet](https://github.com/silverstripe/silverstripe-akismet) - Implement default spam protection via Akismet service
  * [Blog](https://github.com/silverstripe/silverstripe-blog) - The main module for providing blogging functionality.
- * [Lumberjack](https://github.com/silverstripe/silverstripe-lumberjack) - Supporting module for Blog to allow management of pages via gridfield.
+ * [Bulk Editing Tools](https://github.com/colymba/GridFieldBulkEditingTools) - Supporting module for Comments to allow bulk management of comments
  * [Comments](https://github.com/silverstripe/silverstripe-comments) - Allows nested page comments
  * [Comment Notifications](https://github.com/silverstripe-labs/comment-notifications) - Supporting module for Comments to notify authors of blog comments
- * [Bulk Editing Tools](https://gitlab.cwp.govt.nz/cwp/silverstripe-gridfield-bulk-editing-tools) - Supporting module for Comments to allow bulk management of comments
- * [Widgets](https://github.com/silverstripe/silverstripe-widgets) - Adds sidebar widgets
  * [Content Widget](https://github.com/silverstripe-labs/silverstripe-content-widget) - Adds additional sidebar widget for HTML content
- * [Akismet](https://github.com/silverstripe/silverstripe-akismet) - Implement default spam protection via Akismet service
+ * [Lumberjack](https://github.com/silverstripe/silverstripe-lumberjack) - Supporting module for Blog to allow management of pages via gridfield.
  * [Spam Protection](https://github.com/silverstripe/silverstripe-spamprotection) - Supporting module for Akismet to provide core spam protection API
+ * [Widgets](https://github.com/silverstripe/silverstripe-widgets) - Adds sidebar widgets
 
 ## Upgrading
 
@@ -70,63 +70,64 @@ For configuration of anti-spam please see the [Akismet configuration guide](/how
 For the basic configuration, see the default `mysite/_config/blog.yml` below for reference:
 
 
-	:::yml
-	---
-	Name: mywidgetsconfig
-	Only:
-	  moduleexists: widgets
-	---
-	# Disable if you do not use widgets on your site
-	SiteTree:
-	  extensions:
-	    - WidgetPageExtension
-	---
-	Name: mycommentsextension
-	Only:
-	  moduleexists: comments
-	---
-	# Enable page comments on the site by default, including frontend moderation / approval
-	SiteTree:
-	  extensions:
-	    - CommentsExtension
-	  comments:
-	    enabled: false
-	    frontend_moderation: true
-	    require_moderation_nonmembers: true
-	    require_moderation_cms: true
-	    require_login: false
-	    require_login_cms: true
-	    nested_comments: true
-	    order_comments_by: '"Created" ASC'
-	---
-	Name: myblogconfig
-	Only:
-	  moduleexists: blog
-	---
-	# Customise the email notification template here
-	BlogPost:
-	  default_notification_template: 'BlogCommentEmail'
-	  comments:
-	    enabled: true
-	---
-	Name: akismetconfig
-	Only:
-	  moduleexists: akismet
-	---
-	# Customise your akismet configuration here
-	SiteConfig:
-	  extensions:
-	    - AkismetConfig
-	# Allows spam posts to be saved for review if necessary
-	AkismetSpamProtector:
-	  save_spam: true
-	---
-	Name: mycommentspamprotection
-	Only:
-	  moduleexists: spamprotection
-	  classexists: CommentingController
-	---
-	# Enable spam protection for comments by default
-	CommentingController:
-	  extensions:
-	    - CommentSpamProtection
+```yml
+---
+Name: mywidgetsconfig
+Only:
+  moduleexists: widgets
+---
+# Disable if you don't use widgets on your site
+SiteTree:
+  extensions:
+    - WidgetPageExtension
+---
+Name: mycommentsextension
+Only:
+  moduleexists: comments
+---
+# Enable page comments on the site by default, including frontend moderation / approval
+SiteTree:
+  extensions:
+    - CommentsExtension
+  comments:
+    enabled: false
+    frontend_moderation: true
+    require_moderation_nonmembers: true
+    require_moderation_cms: true
+    require_login: false
+    require_login_cms: true
+    nested_comments: true
+    order_comments_by: '"Created" ASC'
+---
+Name: myblogconfig
+Only:
+  moduleexists: blog
+---
+# Customise the email notification template here
+BlogPost:
+  default_notification_template: 'BlogCommentEmail'
+  comments:
+    enabled: true
+---
+Name: akismetconfig
+Only:
+  moduleexists: akismet
+---
+# Customise your akismet configuration here
+SiteConfig:
+  extensions:
+    - AkismetConfig
+# Allows spam posts to be saved for review if necessary
+AkismetSpamProtector:
+  save_spam: true
+---
+Name: mycommentspamprotection
+Only:
+  moduleexists: spamprotection
+  classexists: CommentingController
+---
+# Enable spam protection for comments by default
+CommentingController:
+  extensions:
+    - CommentSpamProtection
+```

--- a/docs/en/02_Features/blog_recipe.md
+++ b/docs/en/02_Features/blog_recipe.md
@@ -8,7 +8,7 @@ engage with you by commenting on your posts. The module supports flexible
 categorisation and tagging of blog posts.
 
 <div class="alert alert-info" markdown='1'>
-From 1.1.0 onwards the `blog recipe` is included along side the basic recipe by default.
+From 1.1.0 onwards the `blog recipe` is included along side the other SilverStripe and CWP recipes by default.
 </div>
 
 [Three levels of permissions are supported](https://github.com/silverstripe/silverstripe-blog/blob/master/docs/en/userguide/roles.md):
@@ -69,26 +69,34 @@ For configuration of anti-spam please see the [Akismet configuration guide](/how
 
 For the basic configuration, see the default `mysite/_config/blog.yml` below for reference:
 
-
 ```yml
 ---
 Name: mywidgetsconfig
 Only:
-  moduleexists: widgets
+  moduleexists:
+    - silverstripe/blog
+    - silverstripe/widgets
 ---
-# Disable if you don't use widgets on your site
-SiteTree:
+# Disable if you do not use widgets on your blog
+SilverStripe\Blog\Model\Blog:
   extensions:
-    - WidgetPageExtension
+    - SilverStripe\Widgets\Extensions\WidgetPageExtension
+
+SilverStripe\Blog\Model\BlogPost:
+  extensions:
+    - SilverStripe\Widgets\Extensions\WidgetPageExtension
+
 ---
-Name: mycommentsextension
+Name: myblogconfig
 Only:
-  moduleexists: comments
+  moduleexists:
+    - silverstripe/blog
+    - silverstripe/comments
 ---
-# Enable page comments on the site by default, including frontend moderation / approval
-SiteTree:
+# Enable page comments for blogs and blog posts on the site by default, including frontend moderation / approval
+SilverStripe\Blog\Model\Blog:
   extensions:
-    - CommentsExtension
+    - SilverStripe\Comments\Extensions\CommentsExtension
   comments:
     enabled: false
     frontend_moderation: true
@@ -98,36 +106,43 @@ SiteTree:
     require_login_cms: true
     nested_comments: true
     order_comments_by: '"Created" ASC'
----
-Name: myblogconfig
-Only:
-  moduleexists: blog
----
-# Customise the email notification template here
-BlogPost:
-  default_notification_template: 'BlogCommentEmail'
+
+SilverStripe\Blog\Model\BlogPost:
+  default_notification_template: SilverStripe\CommentNotifications\BlogCommentEmail
+  extensions:
+    - SilverStripe\Comments\Extensions\CommentsExtension
   comments:
     enabled: true
+    frontend_moderation: true
+    require_moderation_nonmembers: true
+    require_moderation_cms: true
+    require_login: false
+    require_login_cms: true
+    nested_comments: true
+    order_comments_by: '"Created" ASC'
+
 ---
 Name: akismetconfig
 Only:
-  moduleexists: akismet
+  moduleexists: silverstripe/akismet
 ---
 # Customise your akismet configuration here
-SiteConfig:
+SilverStripe\SiteConfig\SiteConfig:
   extensions:
-    - AkismetConfig
+    - SilverStripe\Akismet\Config\AkismetConfig
 # Allows spam posts to be saved for review if necessary
-AkismetSpamProtector:
+SilverStripe\Akismet\AkismetSpamProtector:
   save_spam: true
+
 ---
 Name: mycommentspamprotection
 Only:
-  moduleexists: spamprotection
-  classexists: CommentingController
+  moduleexists:
+    - silverstripe/comments
+    - silverstripe/spamprotection
 ---
 # Enable spam protection for comments by default
-CommentingController:
+SilverStripe\Comments\Controllers\CommentingController:
   extensions:
-    - CommentSpamProtection
-```
+    - SilverStripe\SpamProtection\Extension\CommentSpamProtection
+``` 

--- a/docs/en/02_Features/content_review.md
+++ b/docs/en/02_Features/content_review.md
@@ -7,13 +7,13 @@ Content review in the CWP basic recipe is implemented using:
 
  * [silverstripe/contentreview](https://github.com/silverstripe/silverstripe-contentreview) - provides the main functionality for the feature.
  * [silverstripe/sitewidecontent-report](https://github.com/silverstripe/silverstripe-sitewidecontent-report) - provides an extension and report to show the review status of all content (including across subsites).
- * [silverstripe/queuedjobs](https://github.com/silverstripe-australia/silverstripe-queuedjobs) - handles sending of reminder emails for content review at regular intervals.
+ * [silverstripe/queuedjobs](https://github.com/symbiote/silverstripe-queuedjobs) - handles sending of reminder emails for content review at regular intervals.
  
 Both modules are pre-configured to apply a series of `DataExtension` classes so no additional configuration is required to enable once installed.
 
 ## Sending of content review reminder emails
 
-In order to send reminder emails on CWP you must use the [`silverstripe/queuedjobs`](https://github.com/silverstripe-australia/silverstripe-queuedjobs) module. 
+In order to send reminder emails on CWP you must use the [`silverstripe/queuedjobs`](https://github.com/symbiote/silverstripe-queuedjobs) module. 
 
 This is installed by default when using the CWP basic recipe codebase (if you have used this), otherwise you'll 
 need to ensure you have installed.

--- a/docs/en/02_Features/content_review.md
+++ b/docs/en/02_Features/content_review.md
@@ -15,7 +15,7 @@ Both modules are pre-configured to apply a series of `DataExtension` classes so 
 
 In order to send reminder emails on CWP you must use the [`silverstripe/queuedjobs`](https://github.com/symbiote/silverstripe-queuedjobs) module. 
 
-This is installed by default when using the CWP basic recipe codebase (if you have used this), otherwise you'll 
+This is installed by default when using the [CWP search recipe](https://github.com/silverstripe/cwp-recipe-search) codebase (if you have used this), otherwise you'll 
 need to ensure you have installed.
   
 Queuedjobs will then send content review reminder emails (if any) daily at 9am.  

--- a/docs/en/02_Features/creating_forms.md
+++ b/docs/en/02_Features/creating_forms.md
@@ -5,7 +5,7 @@ summary: How to use the Userforms module to create forms via the CMS
 
 Userforms allows a CMS user to create and edit an email submission form without needing to know any code. You have the ability to add [fields](https://userhelp.silverstripe.org/en/optional_features/forms/field-types), save [form submissions](https://userhelp.silverstripe.org/en/optional_features/forms/form-submissions/) which can then be viewed and exported via the CMS and set up automated emails once a submission takes place.
 
-As a developer you can extend existing fields to create your own fields which are added by a user and also pre fill form fields by passing values via the url (e.g. http://yoursite.com/formpage?EditableField1=MyValue).
+As a developer you can extend existing fields to create your own fields which are added by a user and also prefill form fields by passing values via the url (e.g. http://yoursite.com/formpage?EditableField1=MyValue).
 
 For more information about the userforms module go to the [github repository](https://github.com/silverstripe/silverstripe-userforms) and go to [user documentation](https://userhelp.silverstripe.org/en/optional_features/forms/) for more information about setting up a form in the CMS.
 

--- a/docs/en/02_Features/data_registry.md
+++ b/docs/en/02_Features/data_registry.md
@@ -9,14 +9,14 @@ download a CSV copy of the data for reuse.
 
 The SilverStripe CMS module used to provide this feature is the [`silverstripe/registry`](http://addons.silverstripe.org/add-ons/silverstripe/registry/) module. 
  
-<div class="notice" markdown='1'>This feature is **not** enabled by default in the CWP recipe and must be enabled by a developer first 
+<div class="alert alert-info" markdown='1'>This feature is **not** enabled by default in the CWP recipe and must be enabled by a developer first 
 before a CMS user can use it ([See the user documentation](https://userhelp.silverstripe.org/en/3.2/optional_features/online_databases_and_registries/)).</div>
 
 ## Enabling the data registry
 
 Sets of data that can be displayed are based on the `DataObject` class. To enable any of your `DataObject` 
-subclasses to be exposed via a [Registry Page in the CMS](https://userhelp.silverstripe.org/en/3.2/optional_features/online_databases_and_registries/#adding-a-registry-page) you need to implement an abstract PHP class 
+subclasses to be exposed via a [Registry Page in the CMS](https://github.com/silverstripe/silverstripe-registry/blob/master/docs/en/userguide/index.md) you need to implement an abstract PHP class 
 and ensure you implement the required abstract method, `getSearchFields()`. This allows your set of 
 data to be shown publicly and defines which fields are visible and can be searched on by users.
 
-See the [Registry module technical documentation](https://github.com/silverstripe-labs/silverstripe-registry/blob/master/docs/en/index.md#defining-the-data) for implementation details and code examples.
+See the [Registry module technical documentation](https://github.com/silverstripe/silverstripe-registry/blob/master/docs/en/index.md#defining-the-data) for implementation details and code examples.

--- a/docs/en/02_Features/index.md
+++ b/docs/en/02_Features/index.md
@@ -5,6 +5,6 @@ introduction: This section details major features available in the default recip
 Features specific to CWP only will be documented in this section and many of the default features are well documented alongside the open source modules that enable them. 
 Where possible you'll be directed to the open source documentation as they are the most up to date and useful when looking to customise your SilverStripe CMS website for CWP.
 
-**For general SilverStripe CMS development development, ensure you are using the [official SilverStripe CMS developer documentation](http://docs.silverstripe.org).**  
+**For general SilverStripe CMS development development, ensure you are using the [official SilverStripe CMS developer documentation](https://docs.silverstripe.org/en/4/).**  
 
 [CHILDREN]

--- a/docs/en/02_Features/multiple_sites.md
+++ b/docs/en/02_Features/multiple_sites.md
@@ -13,7 +13,7 @@ The subsites module is already included as part of the CWP basic recipe. To set 
 
 # Technical
 
-There is a good [overview](https://github.com/silverstripe/silverstripe-subsites/blob/1.2/docs/en/introduction.md) to get you familiarised with the module and if you wish to extend the existing subsites architecture then there is some [technical](https://github.com/silverstripe/silverstripe-subsites/blob/1.2/docs/en/technical.md) documentation to get you started.
+There is a good [overview](https://github.com/silverstripe/silverstripe-subsites/blob/master/docs/en/introduction.md) to get you familiarised with the module and if you wish to extend the existing subsites architecture then there is some [technical](https://github.com/silverstripe/silverstripe-subsites/blob/1.2/docs/en/technical.md) documentation to get you started.
 
 ## Go live
 

--- a/docs/en/02_Features/pdf_export.md
+++ b/docs/en/02_Features/pdf_export.md
@@ -51,13 +51,13 @@ There is a Mac OS X download, and there may be a Windows binary for `wkhtmltopdf
 * [Download wkhtmltopdf](https://wkhtmltopdf.org/downloads.html) for your system type:
 
   ```
-  wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4.tar.bz2
+  wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.1.1/wkhtmltox-0.12.1.1.tar.bz2
   ```
 
 * Install it into `/usr/local/bin` so that it can be accessed on the path:
 
   ```
-  tar -jxvf wkhtmltox-0.12.4.tar.bz2
+  tar -jxvf wkhtmltox-0.12.1.1.tar.bz2
   mv wkhtmltopdf-amd64 /usr/local/bin/wkhtmltopdf
   ```
 

--- a/docs/en/02_Features/pdf_export.md
+++ b/docs/en/02_Features/pdf_export.md
@@ -15,8 +15,8 @@ installed for this functionality to be enabled.
 A special `$PdfLink` variable is provided to the templates, which if applied as the value of an `href` value to an
 anchor in the template, will provide users with a way to download the a PDF version of the current page.
 
-<div class="notice" markdown='1'>
-This variable is commented out by default in the starter and Wātea themes. You can re-enable it by uncommenting these lines in `PageUtilities.ss`.
+<div class="alert alert-info" markdown='1'>
+This variable is commented out by default in the CWP Starter and Wātea themes. You can re-enable it by uncommenting these lines in `PageUtilities.ss`.
 </div>
 
 When the user requests a PDF of the page, the page is exported as HTML by SilverStripe and then passed along to
@@ -33,31 +33,31 @@ by removing the `--print-media-type` parameter to `wkhtmltopdf`.
 
 ## Limitations
 
-Draft content cannot be exported to PDF, due to the fact that generated PDF files are publicly accessible by anyone
+Draft content can't be exported to PDF, due to the fact that generated PDF files are publicly accessible by anyone
 viewing the website, there are no permission checks when accessing files directly in the browser.
 
 ## Installation
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 The CWP test and production servers you'll be deploying your site to already have `wkhtmltopdf` installed.
 These instructions are only necessary if you want to develop or use the PDF export functionality in your local
-development environment. Skip to "Enabling PDF export ..." below if you simply want to enable the PDF export
+development environment. Skip to [Enabling PDF export ...](#enabling-pdf-export-functionality) below if you simply want to enable the PDF export
 functionality.
 
 The instructions below assume you're on a Debian or Ubuntu Linux environment.
 There is a Mac OS X download, and there may be a Windows binary for `wkhtmltopdf` but they have not been tested.
 </div>
 
-* [Download wkhtmltopdf](http://code.google.com/p/wkhtmltopdf/downloads/list) for your system type:
+* [Download wkhtmltopdf](https://wkhtmltopdf.org/downloads.html) for your system type:
 
   ```
-  wget http://wkhtmltopdf.googlecode.com/files/wkhtmltopdf-0.9.9-static-amd64.tar.bz2
+  wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4.tar.bz2
   ```
 
 * Install it into `/usr/local/bin` so that it can be accessed on the path:
 
   ```
-  tar -jxvf wkhtmltopdf-0.9.9-static-amd64.tar.bz2
+  tar -jxvf wkhtmltox-0.12.4.tar.bz2
   mv wkhtmltopdf-amd64 /usr/local/bin/wkhtmltopdf
   ```
 
@@ -80,9 +80,9 @@ There is a Mac OS X download, and there may be a Windows binary for `wkhtmltopdf
   ```
 
 If you're on Debian "squeeze" you might need to add `contrib` to the `squeeze` sources in `/etc/apt/sources.list` if
-the above command cannot find `ttf-mscorefonts-installer`.
+the above command can't find `ttf-mscorefonts-installer`.
 
-Note the [licensing information](http://www.microsoft.com/typography/RedistributionFAQ.mspx) provided by Microsoft.
+Note the [licensing information](https://docs.microsoft.com/en-us/typography/fonts/font-faq) provided by Microsoft.
 This means those fonts such as Arial can be embedded in the PDF document, provided they are for "Print and preview"
 only.
 
@@ -97,7 +97,7 @@ CWP\CWP\PageTypes\BasePage:
   pdf_export: 1
 ```
 
-Note the yml files do not accept tabs, only spaces. You'll also have to call `flush=1` to have the new YML configuration
+Note the yml files don't accept tabs, only spaces. You'll also have to call `flush=1` to have the new YML configuration
 take effect.
 
 Now you can use `$PdfLink` in your templates which gives you a link to generate the page as a PDF.

--- a/docs/en/02_Features/realme_authentication.md
+++ b/docs/en/02_Features/realme_authentication.md
@@ -15,7 +15,7 @@ integration, and will need to work with web developers to build whatever the sys
 only, or with SMS/Token as second factor) and only RealMe logon accounts. Support for RealMe verified accounts is 
 something that an interested agency could commission SilverStripe to add.
 
-This module doesn't come bundled in the CWP Basic Recipe, as it requires a number of steps to be completed by the 
+This module doesn't come bundled in the CWP installer, as it requires a number of steps to be completed by the 
 agency prior to being enabled, these are outlined below.
 
 Agencies are encouraged to [discuss their requirements with the RealMe team](https://www.realme.govt.nz/realme-business/) 

--- a/docs/en/02_Features/realme_authentication.md
+++ b/docs/en/02_Features/realme_authentication.md
@@ -7,7 +7,7 @@ The [RealMe module](https://github.com/silverstripe/silverstripe-realme/) enable
 government's preferred approach for website authentication, to deliver online services or restrict information to 
 specific people.
 
-<div class="notice" markdown='1'>This module is only supported from cwp recipe 1.2.0 and above</div>
+<div class="alert alert-info" markdown='1'>This module is only supported from cwp recipe 1.2.0 and above.</div>
 
 The module facilitates the log-on process; agencies need to work with the RealMe team to conduct the 
 integration, and will need to work with web developers to build whatever the system performs after you have logged in 
@@ -15,7 +15,7 @@ integration, and will need to work with web developers to build whatever the sys
 only, or with SMS/Token as second factor) and only RealMe logon accounts. Support for RealMe verified accounts is 
 something that an interested agency could commission SilverStripe to add.
 
-This module does not come bundled in the CWP Basic Recipe, as it requires a number of steps to be completed by the 
+This module doesn't come bundled in the CWP Basic Recipe, as it requires a number of steps to be completed by the 
 agency prior to being enabled, these are outlined below.
 
 Agencies are encouraged to [discuss their requirements with the RealMe team](https://www.realme.govt.nz/realme-business/) 
@@ -28,7 +28,7 @@ and working through the requirements.
 
 The CWP Operations team is available to assist with the integration of the ITE (Integrated Test Environment) and 
 production environments, which map to your CWP UAT and production environments. Please 
-[create a service desk ticket](https://www.cwp.govt.nz/service-desk/new-request/) once you are ready for integration to 
+[create a CWP Service Desk ticket](https://www.cwp.govt.nz/service-desk/new-request/) once you are ready for integration to 
 be setup. The CWP Operations team will then generate the required SSL certificates, configure your UAT and production 
 environments, and provide you with the necessary XML metadata to submit to RealMe in order to establish the two-way 
 trusted chain that your developers set up while running through the installation instructions for their own development 
@@ -45,4 +45,4 @@ If there are any further questions, please don't hesitate to
 
 ## See Also
 
- * [Single Sign on via Active Directory](active_directory_single_sign_on)
+ * [Single sign-on via Active Directory](active_directory_single_sign_on)

--- a/docs/en/02_Features/related_pages.md
+++ b/docs/en/02_Features/related_pages.md
@@ -9,18 +9,23 @@ In the templates this is all handled by including `RelatedPages.ss`. You can cus
 the page control `RelatedPages`, this will provide you with a Page object from which you can read `Title`, `Link`, and
 any other variable or action defined on the page. This is a snippet from how it is implemented in `RelatedPages.ss`:
 
-	:::html
-	<ul>
-		<% loop RelatedPages %>
-			<li><a href="$Link">$Title</a></li>
-		<% end_loop %>
-	</ul>
+```html
+<ul>
+    <% loop RelatedPages %>
+        <li><a href="$Link">$Title</a></li>
+    <% end_loop %>
+</ul>
+```
 
 The title defaults to "Related Pages". For any page type you can override this by defining a static variable called
 `$related_pages_title`. For example:
 
-	:::php
-	class StaffMemberPage extends Page {
-		public static $related_pages_title = 'Offices';
-		...
-	}
+```php
+use Page;
+
+class StaffMemberPage extends Page 
+{
+    public static $related_pages_title = 'Offices';
+    ...
+}
+```

--- a/docs/en/02_Features/related_pages.md
+++ b/docs/en/02_Features/related_pages.md
@@ -25,7 +25,7 @@ use Page;
 
 class StaffMemberPage extends Page 
 {
-    public static $related_pages_title = 'Offices';
+    private static $related_pages_title = 'Offices';
     ...
 }
 ```

--- a/docs/en/02_Features/reports.md
+++ b/docs/en/02_Features/reports.md
@@ -23,4 +23,4 @@ To look at the report, go to the "Reports" section and select "Site-wide content
 ## Developing custom reports
 Custom reports can be created quickly and easily. A general knowledge of SilverStripe CMS's datamodel and ORM is useful before creating a custom report.
 
-See [Customising site reports](https://docs.silverstripe.org/en/3.2/developer_guides/customising_the_admin_interface/how_tos/customise_site_reports/) in the Official SilverStripe CMS documentation
+See [Customising site reports](https://docs.silverstripe.org/en/4/developer_guides/customising_the_admin_interface/how_tos/customise_site_reports/) in the Official SilverStripe CMS documentation

--- a/docs/en/02_Features/rich_links.md
+++ b/docs/en/02_Features/rich_links.md
@@ -33,9 +33,9 @@ being provided in this specific format.
 The capability is built as a simple extension to `DBField`. It is applied in `cwp/_config/config.yml`:
 
 ```yml
-DBField:
+SilverStripe\ORM\FieldType\DBField:
   extensions:
-   - RichLinksExtension
+   - CWP\Core\Extension\RichLinksExtension
 ```
 
 It provides all fields with a `RichLinks` function.

--- a/docs/en/02_Features/rich_links.md
+++ b/docs/en/02_Features/rich_links.md
@@ -15,13 +15,15 @@ The following abilities are included:
 
 To use the feature, explicitly invoke the parser function within the template.
 
-	:::html
-	$Content.RichLinks
+```html
+$Content.RichLinks
+```
 
 You can also chain it with other functions to achieve more complex outputs.
 
-	:::html
-	$Content.RichLinks.LimitWordCountXML(10)
+```html
+$Content.RichLinks.LimitWordCountXML(10)
+```
 
 Note: this parser might not work as expected on fields not edited with *HtmlEditorField*, as it relies on the content
 being provided in this specific format.
@@ -30,10 +32,11 @@ being provided in this specific format.
 
 The capability is built as a simple extension to `DBField`. It is applied in `cwp/_config/config.yml`:
 
-	:::yml
-	DBField:
-	  extensions:
-	   - RichLinksExtension
+```yml
+DBField:
+  extensions:
+   - RichLinksExtension
+```
 
 It provides all fields with a `RichLinks` function.
 

--- a/docs/en/02_Features/translations.md
+++ b/docs/en/02_Features/translations.md
@@ -7,12 +7,12 @@ The [SilverStripe Fluent](https://github.com/tractorcow/silverstripe-fluent) mod
 multiple pages in various languages or locales within languages. This module also adds the ability for your users
 to select which language of a page they wish to view.
 
-<div class="notice" markdown='1'>The SilverStripe Fluent module does not translate content automatically, content
-authors will need to enter the translated content manually for each translated page</div>
+<div class="alert alert-info" markdown='1'>The SilverStripe Fluent module does not translate content automatically, content
+authors will need to enter the translated content manually for each translated page.</div>
 
 ## Setup
 
-The Fluent module is already included as part of the CWP basic recipe and the starter and Wātea CWP themes are
+The Fluent module is already included as part of the CWP installer and the CWP Starter and Wātea themes are
 set up to switch between different languages.
 
 To set up new locales in the CMS, navigate to the "Locales" tab and start creating new locales. You can switch
@@ -22,7 +22,7 @@ selected locale will be saved for that locale.
 You can also define inheritance for locales, meaning content that isn't modified at a certain locale can be inherited
 from the "fallback locale".
 
-For more information on using Fluent, please see the [module documentation](https://github.com/tractorcow/silverstripe-fluent/blob/4.0.0-beta2/readme.md).
+For more information on using Fluent, please see the [module documentation](https://github.com/tractorcow/silverstripe-fluent/blob/master/readme.md).
 
 ## Technical
 

--- a/docs/en/03_How_tos/adding_a_calendar.md
+++ b/docs/en/03_How_tos/adding_a_calendar.md
@@ -15,9 +15,10 @@ One option would be to use SilverStripe Framework's ORM to create a normal `Data
 But to make things simpler (albeit less customisable) we can also use the wrapper function provided by the `EventHolder`
 class. Let's take a closer look at the function declaration.
 
-	:::php
-	public static function AllEvents($parentID = null, $tagID = null, $dateFrom = null, $dateTo = null, $year = null,
-			$monthNumber = null)
+```php
+public static function AllEvents($parentID = null, $tagID = null, $dateFrom = null, $dateTo = null, $year = null,
+        $monthNumber = null)
+```
 
 The only thing we are looking to control is the currently displayed month. This variant provides us with `$year` and
 `$monthNumber` that allow us to do so.
@@ -30,36 +31,41 @@ parameters can then be passed to `AllEvents` to produce the single-month listing
 We can create a function that will parse the parameters and provide us with a neat array of SQL-safe variables. We start
 by getting the parameters from the `SS_HTTPRequest`.
 
-	:::php
-	public function parseEventParams() {
-		$year = $this->request->getVar('year');
-		$month = $this->request->getVar('month');
+```php
+public function parseEventParams() 
+{
+    $year = $this->request->getVar('year');
+    $month = $this->request->getVar('month');
+```
 
 We need to sanitise them before doing anything else. We could use `Convert` helper class to do it, or simply cast the
 value:
 
-	:::php
-		if (isset($year)) $year = (int)$year;
-		if (isset($month)) $month = (int)$month;
+```php
+    if (isset($year)) $year = (int)$year;
+    if (isset($month)) $month = (int)$month;
+```
 
 Next, since the month without year doesn't have much sense, we make sure that we check for validity and reset to
 defaults if needed. This assures us that we don't end up displaying a listing of all site events.
 
-	:::php
-		// Default to current month if either not provided.
-		if (!isset($month) || !isset($year)) {
-			$year = SS_Datetime::now()->Format('Y');
-			$month = SS_Datetime::now()->Format('m');
-		}
+```php
+    // Default to current month if either not provided.
+    if (!isset($month) || !isset($year)) {
+        $year = SS_Datetime::now()->Format('Y');
+        $month = SS_Datetime::now()->Format('m');
+    }
+```
 
 Then we return the array with cleaned up data that we will use shortly.
 
-	:::php
-		return array(
-			'year' => $year,
-			'month' => $month
-		);
-	}
+```php
+    return [
+        'year' => $year,
+        'month' => $month
+    ];
+}
+```
 
 Note that these parameters need to be `year` and `month` since that's what `EventHolder::ExtractMonth` (described
 later) uses internally.
@@ -69,32 +75,36 @@ later) uses internally.
 Now that we have the parameters available, we can combine that with `AllEvents` to fetch the data and show it in the
 template. Let's create a getter in the `Page_Controller` (or wherever you are attempting to create the calendar).
 
-	:::php
-	public function SiteEvents() {
-		$params = $this->parseEventParams();
-		return EventHolder::AllEvents(null, null, null, null, $params['year'], $params['month']);
-	}
+```php
+public function SiteEvents() 
+{
+    $params = $this->parseEventParams();
+    return EventHolder::AllEvents(null, null, null, null, $params['year'], $params['month']);
+}
+```
 
 We can now access the events for the currently selected (or default) month in the template, say `Page.ss`. Here is how
 to iteratively loop through the events:
 
-	:::ss
-		<h3>Site Events</h3>
-		<% loop SiteEvents %>
-			<div class="event-listing">
-				<h4><a href="$Link">$Title</a></h4>
-				<p>$Date.Nice $StartTime.Nice - $EndTime.Nice</p>
-			</div>
-		<% end_loop %>
+```ss
+    <h3>Site Events</h3>
+    <% loop SiteEvents %>
+        <div class="event-listing">
+            <h4><a href="$Link">$Title</a></h4>
+            <p>$Date.Nice $StartTime.Nice - $EndTime.Nice</p>
+        </div>
+    <% end_loop %>
+```
 
 We can also provide an alternative string if no events are found:
 
-	:::ss
-	<% if SiteEvents %>
-		... above event loop
-	<% else %>
-		<p>No events. Please use the month picker below to select another period.</p>
-	<% end_if %>
+```ss
+<% if SiteEvents %>
+    ... above event loop
+<% else %>
+    <p>No events. Please use the month picker below to select another period.</p>
+<% end_if %>
+```
 
 We can already test this snippet of code (this is using the *default* theme and Bootstrap `well` and `span3` classes):
 
@@ -118,44 +128,47 @@ Since we actually want to extract months from all events on the site we will use
 parameters. Supplying current month and year allows `ExtractMonths` to provide us with a flag marking the current
 month so we can highlight it in the frontend.
 
-	:::php
-	public function SiteEventMonths() {
-		$params = $this->parseEventParams();
-		
-		return EventHolder::ExtractMonths(
-			// This is the list of events to walk through.
-			EventHolder::AllEvents(),
-			// The link will default to current URL, which we want.
-			null,
-			// These are for producing the "Active" flag on resulting months.
-			$params['year'],
-			$params['month']
-		);
-	}
+```php
+public function SiteEventMonths() 
+{
+    $params = $this->parseEventParams();
+    
+    return EventHolder::ExtractMonths(
+        // This is the list of events to walk through.
+        EventHolder::AllEvents(),
+        // The link will default to current URL, which we want.
+        null,
+        // These are for producing the "Active" flag on resulting months.
+        $params['year'],
+        $params['month']
+    );
+}
+```
 
-The returned data structure (detailed in `EventHolder` as well) will alow us to construct the template pagination
+The returned data structure (detailed in `EventHolder` as well) will allow us to construct the template pagination
 control. Here is an example of this with some extra comments added in (see at the bottom of this how-to for the full
 listing).
 
-	:::ss
-	<h5>Pick a month</h5>
-	
-	<div class="month-filter">
-		<%-- Loop through years first --%>
-		<% loop SiteEventMonths %>
-			<h6 class="year">$YearName:</h6>
-		
-			<%-- Then loop through months within each year --%>
-			<ol class="nav nav-pills unstyled months">
-				<% loop Months %>
-		
-					<%-- use the Active, MonthLink and MonthName to produce the pagination --%>
-					<li <% if Active %>class="active"<% end_if %>><a href="$MonthLink.XML">$MonthName</a></li>
-		
-				<% end_loop %>
-			</ol>
-		<% end_loop %>
-	</div>
+```ss
+<h5>Pick a month</h5>
+
+<div class="month-filter">
+    <%-- Loop through years first --%>
+    <% loop SiteEventMonths %>
+        <h6 class="year">$YearName:</h6>
+    
+        <%-- Then loop through months within each year --%>
+        <ol class="nav nav-pills unstyled months">
+            <% loop Months %>
+    
+                <%-- use the Active, MonthLink and MonthName to produce the pagination --%>
+                <li <% if Active %>class="active"<% end_if %>><a href="$MonthLink.XML">$MonthName</a></li>
+    
+            <% end_loop %>
+        </ol>
+    <% end_loop %>
+</div>
+```
 
 The `Active` will be set to true for the month that is the same as the currently selected one. The `MonthLink` is the
 link built on the basis of the current URL, plus the `year` and `month` GET params needed for selecting the relevant
@@ -171,20 +184,21 @@ We don't have to display all events in the calendar. It's just as meaningful to 
 specific tag. The modification is simple. Get the tag using the ORM as you'd normally do and provide its ID as the
 second parameter to both `AllEvents` function used in this how-to.
 
-	:::php
-	// Get the tag
-	$tag = TaxonomyTerm::get()->filter(array('Name' => 'Future'))->First();
-	...
-	// Modify both AllEvents call in SiteEvents
-	return EventHolder::AllEvents(null, $tag->ID, null, null, $params['year'], $params['month']);
-	...
-	// And in SiteEventMonths
-	return EventHolder::ExtractMonths(
-		EventHolder::AllEvents(null, $tag->ID),
-		null,
-		$params['year'],
-		$params['month']
-	);
+```php
+// Get the tag
+$tag = TaxonomyTerm::get()->filter(['Name' => 'Future')]->First();
+...
+// Modify both AllEvents call in SiteEvents
+return EventHolder::AllEvents(null, $tag->ID, null, null, $params['year'], $params['month']);
+...
+// And in SiteEventMonths
+return EventHolder::ExtractMonths(
+    EventHolder::AllEvents(null, $tag->ID),
+    null,
+    $params['year'],
+    $params['month']
+);
+```
 
 That will filter out events that are not marked as "Future".
 
@@ -194,82 +208,87 @@ That will filter out events that are not marked as "Future".
 
 Code for `Page_Controller` class (or your custom page type):
 
-	:::php
-	public function parseEventParams() {
-		$year = $this->request->getVar('year');
-		$month = $this->request->getVar('month');
-		if (isset($year)) $year = (int)$year;
-		if (isset($month)) $month = (int)$month;
-	
-		// Default to current month if either not provided.
-		if (!isset($month) || !isset($year)) {
-			$year = SS_Datetime::now()->Format('Y');
-			$month = SS_Datetime::now()->Format('m');
-		}
-	
-		return array(
-			'year' => $year,
-			'month' => $month
-		);
-	}
-	
-	/**
-	 * Prepare the data structure on which navigation can be built.
-	 */
-	public function SiteEventMonths() {
-		$params = $this->parseEventParams();
-	
-		return EventHolder::ExtractMonths(
-			EventHolder::AllEvents(),
-			null,
-			$params['year'],
-			$params['month']
-		);
-	
-	}
-	
-	/**
-	 * Produce a list of events, as assigned to the current or currently selected month.
-	 */
-	public function SiteEvents() {
-		$params = $this->parseEventParams();
-	
-		return EventHolder::AllEvents(null, null, null, null, $params['year'], $params['month']);
-	}
+```php
+public function parseEventParams() 
+{
+    $year = $this->request->getVar('year');
+    $month = $this->request->getVar('month');
+    if (isset($year)) $year = (int)$year;
+    if (isset($month)) $month = (int)$month;
+
+    // Default to current month if either not provided.
+    if (!isset($month) || !isset($year)) {
+        $year = SS_Datetime::now()->Format('Y');
+        $month = SS_Datetime::now()->Format('m');
+    }
+
+    return [
+        'year' => $year,
+        'month' => $month
+    ];
+}
+
+/**
+ * Prepare the data structure on which navigation can be built.
+ */
+public function SiteEventMonths() 
+{
+    $params = $this->parseEventParams();
+
+    return EventHolder::ExtractMonths(
+        EventHolder::AllEvents(),
+        null,
+        $params['year'],
+        $params['month']
+    );
+
+}
+
+/**
+ * Produce a list of events, as assigned to the current or currently selected month.
+ */
+public function SiteEvents() 
+{
+    $params = $this->parseEventParams();
+
+    return EventHolder::AllEvents(null, null, null, null, $params['year'], $params['month']);
+}
+```
 
 Code for `Page.ss` template:
 
-	:::ss
-	<div class="span3 well">
-	
-		<h3>Site events</h3>
-	
-		<% if SiteEvents %>
-			<% loop SiteEvents %>
-				<div class="event-listing">
-					<h4><a href="$Link">$Title</a></h4>
-					<p>$Date.Nice $StartTime.Nice - $EndTime.Nice</p>
-				</div>
-			<% end_loop %>
-		<% else %>
-			<p>No events. Please use the month picker below to select another period.</p>
-		<% end_if %>
-	
-		<div class="event-listing-pagination">
-			<h5>Pick a month</h5>
-	
-			<% if SiteEventMonths %>
-				<div class="month-filter">
-					<% loop SiteEventMonths %>
-						<h6 class="year">$YearName:</h6>
-						<ol class="nav nav-pills unstyled months">
-						<% loop Months %>
-							<li <% if Active %>class="active"<% end_if %>><a href="$MonthLink.XML">$MonthName</a></li>
-						<% end_loop %>
-						</ol>
-					<% end_loop %>
-				</div>
-			<% end_if %>
-		</div>
-	</div>
+```ss
+<div class="span3 well">
+
+    <h3>Site events</h3>
+
+    <% if SiteEvents %>
+        <% loop SiteEvents %>
+            <div class="event-listing">
+                <h4><a href="$Link">$Title</a></h4>
+                <p>$Date.Nice $StartTime.Nice - $EndTime.Nice</p>
+            </div>
+        <% end_loop %>
+    <% else %>
+        <p>No events. Please use the month picker below to select another period.</p>
+    <% end_if %>
+
+    <div class="event-listing-pagination">
+        <h5>Pick a month</h5>
+
+        <% if SiteEventMonths %>
+            <div class="month-filter">
+                <% loop SiteEventMonths %>
+                    <h6 class="year">$YearName:</h6>
+                    <ol class="nav nav-pills unstyled months">
+                    <% loop Months %>
+                        <li <% if Active %>class="active"<% end_if %>><a href="$MonthLink.XML">$MonthName</a></li>
+                    <% end_loop %>
+                    </ol>
+                <% end_loop %>
+            </div>
+        <% end_if %>
+    </div>
+</div>
+```
 

--- a/docs/en/03_How_tos/adding_a_calendar.md
+++ b/docs/en/03_How_tos/adding_a_calendar.md
@@ -29,7 +29,7 @@ The month selection is done (similarly to `EventHolder`) on the basis of the `ye
 parameters can then be passed to `AllEvents` to produce the single-month listing.
 
 We can create a function that will parse the parameters and provide us with a neat array of SQL-safe variables. We start
-by getting the parameters from the `SS_HTTPRequest`.
+by getting the parameters from the `HTTPRequest`.
 
 ```php
 public function parseEventParams() 
@@ -42,18 +42,26 @@ We need to sanitise them before doing anything else. We could use `Convert` help
 value:
 
 ```php
-    if (isset($year)) $year = (int)$year;
-    if (isset($month)) $month = (int)$month;
+    if (isset($year)) {
+        $year = (int)$year;
+    }
+    if (isset($month)) {
+        $month = (int)$month;
+    }
 ```
 
 Next, since the month without year doesn't have much sense, we make sure that we check for validity and reset to
 defaults if needed. This assures us that we don't end up displaying a listing of all site events.
 
 ```php
+use SilverStripe\ORM\FieldType\DBDatetime;
+
+//...
+
     // Default to current month if either not provided.
     if (!isset($month) || !isset($year)) {
-        $year = SS_Datetime::now()->Format('Y');
-        $month = SS_Datetime::now()->Format('m');
+        $year = DBDatetime::now()->Format('y');
+        $month = DBDatetime::now()->Format('MM');
     }
 ```
 
@@ -209,6 +217,10 @@ That will filter out events that are not marked as "Future".
 Code for `Page_Controller` class (or your custom page type):
 
 ```php
+use SilverStripe\ORM\FieldType\DBDatetime;
+
+//...
+
 public function parseEventParams() 
 {
     $year = $this->request->getVar('year');
@@ -218,8 +230,8 @@ public function parseEventParams()
 
     // Default to current month if either not provided.
     if (!isset($month) || !isset($year)) {
-        $year = SS_Datetime::now()->Format('Y');
-        $month = SS_Datetime::now()->Format('m');
+        $year = DBDatetime::now()->Format('y');
+        $month = DBDatetime::now()->Format('MM');
     }
 
     return [
@@ -257,7 +269,7 @@ public function SiteEvents()
 
 Code for `Page.ss` template:
 
-```ss
+```html
 <div class="span3 well">
 
     <h3>Site events</h3>

--- a/docs/en/03_How_tos/akismet.md
+++ b/docs/en/03_How_tos/akismet.md
@@ -38,7 +38,7 @@ You can also add the following YAML code into your mysite/_config/config.yml
 ---
 Name: myspamprotection
 ---
-AkismetSpamProtector:
+SilverStripe\Akismet\AkismetSpamProtector:
   api_key: XXXXXXXXXXXXX
 ```
 
@@ -50,7 +50,9 @@ a site has multiple keys controlled by business logic via php.
 
 
 ```php
-define('SS_AKISMET_API_KEY', 'XXXXXXXXXXXXX');
+use SilverStripe\Core\Environment;
+
+Environment::setEnv('SS_AKISMET_API_KEY', 'XXXXXXXXXXXXX');
 ```
 
 

--- a/docs/en/03_How_tos/akismet.md
+++ b/docs/en/03_How_tos/akismet.md
@@ -34,12 +34,13 @@ to store this value.
 You can also add the following YAML code into your mysite/_config/config.yml
 
 
-	:::yml
-	---
-	Name: myspamprotection
-	---
-	AkismetSpamProtector:
-	  api_key: XXXXXXXXXXXXX
+```yml
+---
+Name: myspamprotection
+---
+AkismetSpamProtector:
+  api_key: XXXXXXXXXXXXX
+```
 
 
 ### Configure via _config.php
@@ -48,8 +49,9 @@ You can also add the below code (or some similar version) to your _config.php. T
 a site has multiple keys controlled by business logic via php.
 
 
-	:::php
-	define('SS_AKISMET_API_KEY', 'XXXXXXXXXXXXX');
+```php
+define('SS_AKISMET_API_KEY', 'XXXXXXXXXXXXX');
+```
 
 
 ### Security

--- a/docs/en/03_How_tos/atomfeed.md
+++ b/docs/en/03_How_tos/atomfeed.md
@@ -5,17 +5,17 @@ summary: Creating custom Atom feeds (RSS).
 
 The `CwpAtomFeed` class extends from the `RSSFeed` class.
 
-To setup a Atom feed [follow the documentation for setting up a RSS Feed](https://docs.silverstripe.org/en/3.2/developer_guides/integration/rssfeed/) 
+To setup a Atom feed [follow the documentation for setting up a RSS Feed](https://docs.silverstripe.org/en/4/developer_guides/integration/rssfeed/) 
 and replace the `RSSFeed` class with the `CwpAtomFeed` class.
 
 ### Customizing the Atom Feed template
 
- - The default template used is located at `cwp-core/templates/AtomFeed.ss`
- - The template for news items is located at `themes/default/templates/NewsHolder_atom.ss`
- - The template for search results is located at `themes/default/templates/Page_results_atom.ss`
- - The template for printing and subscribing to feeds is located at `themes/default/templates/Includes/PrintShare.ss`
+ - The default template used is located at `cwp-core/templates/CWP/Core/Feed/CWPAtomFeed.ss`
+ - The template for news items is located at `themes/starter/templates/CWP/CWP/PageTypes/NewsHolder_atom.ss`
+ - The template for search results is located at `themes/starter/templates/Page_results_atom.ss`
+ - The template for printing and subscribing to feeds is located at `themes/starter/templates/Includes/PageUtilities.ss`
  - You may want to modify this template to replace the default RSS feed subscribe link for the Atom feed link by replacing `$RSSLink` with `$AtomLink`.
 
 ## API Documentation
 
-* `[api:RSSFeed]`
+* [RSSFeed](http://api.silverstripe.org/4/SilverStripe/Control/RSS/RSSFeed.html)

--- a/docs/en/03_How_tos/basic_auth.md
+++ b/docs/en/03_How_tos/basic_auth.md
@@ -21,7 +21,7 @@ By default the permission "Allow users to use their accounts to access the UAT s
 UAT and test environments have basic auth enabled by default. You can disable this in your code base with the
 following code in your `config.yml`:
 
-```
+```yml
 ---
 Name: mysitesecuritytest
 After: '#cwpsecuritytest'

--- a/docs/en/03_How_tos/contributing_translations.md
+++ b/docs/en/03_How_tos/contributing_translations.md
@@ -10,6 +10,9 @@ translations will be merged back to the project source code.
 Please register on Transifex and you will be able to contribute to all modules. Here is a list of translation projects
 for CWP-hosted modules:
 
-* [cwp/cwp](https://www.transifex.com/projects/p/silverstripe-cwp/)
-* [cwp/cwp-core](https://www.transifex.com/projects/p/silverstripe-cwp-core/)
-* [silverstripe/documentconverter](https://www.transifex.com/projects/p/silverstripe-documentconverter/)
+* [cwp/cwp](https://www.transifex.com/silverstripe/silverstripe-cwp/)
+* [cwp/cwp-core](https://www.transifex.com/silverstripe/silverstripe-cwp-core/)
+* [cwp/cwp-installer](https://www.transifex.com/silverstripe/silverstripe-cwp-installer/)
+* [cwp/cwp-search](https://www.transifex.com/silverstripe/silverstripe-cwp-search/)
+* [cwp-themes/default](https://www.transifex.com/silverstripe/silverstripe-cwp-themes-default/)
+* [silverstripe/documentconverter](https://www.transifex.com/silverstripe/silverstripe-documentconverter/)

--- a/docs/en/03_How_tos/contributing_translations.md
+++ b/docs/en/03_How_tos/contributing_translations.md
@@ -7,12 +7,4 @@ Translations of the natural language strings are managed through a third party t
 [Transifex](http://transifex.com). Newly added strings will be periodically uploaded there for translation, and any new
 translations will be merged back to the project source code.
 
-Please register on Transifex and you will be able to contribute to all modules. Here is a list of translation projects
-for CWP-hosted modules:
-
-* [cwp/cwp](https://www.transifex.com/silverstripe/silverstripe-cwp/)
-* [cwp/cwp-core](https://www.transifex.com/silverstripe/silverstripe-cwp-core/)
-* [cwp/cwp-installer](https://www.transifex.com/silverstripe/silverstripe-cwp-installer/)
-* [cwp/cwp-search](https://www.transifex.com/silverstripe/silverstripe-cwp-search/)
-* [cwp-themes/default](https://www.transifex.com/silverstripe/silverstripe-cwp-themes-default/)
-* [silverstripe/documentconverter](https://www.transifex.com/silverstripe/silverstripe-documentconverter/)
+Please register on Transifex and you will be able to contribute to all modules.

--- a/docs/en/03_How_tos/custom_embeds_in_the_WYSIWYG_editor.md
+++ b/docs/en/03_How_tos/custom_embeds_in_the_WYSIWYG_editor.md
@@ -6,7 +6,7 @@ summary: How to allow custom embeds in the TinyMCE HTML editor.
 This how-to guides developers through the steps necessary to disable default TinyMCE handling
 of the `<embed>` and `<object>` tags.
 
-<div class="notice" markdown='1'>
+<div class="alert alert-info" markdown='1'>
 Proceeding with this guide will disable the ability of the CMS to embed `.swf` files through the "Insert Media"
 interface button. You will need to provide your own [custom TinyMCE
 plugins](https://docs.silverstripe.org/en/3.2/developer_guides/forms/field_types/htmleditorfield) or embed the files directly via HTML
@@ -21,11 +21,12 @@ and attributes.
 
 In your module's `_config.php` (the module's name has to be alphabetically after `cwp` for your `_config.php` statements
 not to be overriden, see the notice in the [Rich Text Editing
-docs](https://docs.silverstripe.org/en/3.2/developer_guides/forms/field_types/htmleditorfield/)) disable the media plugin for the
+docs](https://docs.silverstripe.org/en/4/developer_guides/forms/field_types/htmleditorfield/)) disable the media plugin for the
 default editor installed by the `cwp` module:
 
-	:::php
-	HtmlEditorConfig::get('cwp')->disablePlugin('media');
+```php
+HtmlEditorConfig::get('cwp')->disablePlugin('media');
+```
 
 Note the editor configuration we want to amend is "cwp" here, different from the default SilverStripe configuration
 called "cms".
@@ -37,5 +38,6 @@ You should now be able to embed any `<embed>` or `<object>` using the HTML butto
 If you find out some attributes are still being removed by the editor, your can update the whitelist of elements.
 Copy the `extended_valid_elements` option from `cwp/_config.php`, and amend it in your own `_config.php` to suit.
 
-	:::php
-	HtmlEditorConfig::get('cwp')->setOption('extended_valid_elements', '<your modified whitelist goes here>');
+```php
+HtmlEditorConfig::get('cwp')->setOption('extended_valid_elements', '<your modified whitelist goes here>');
+```

--- a/docs/en/03_How_tos/custom_embeds_in_the_WYSIWYG_editor.md
+++ b/docs/en/03_How_tos/custom_embeds_in_the_WYSIWYG_editor.md
@@ -8,9 +8,9 @@ of the `<embed>` and `<object>` tags.
 
 <div class="alert alert-info" markdown='1'>
 Proceeding with this guide will disable the ability of the CMS to embed `.swf` files through the "Insert Media"
-interface button. You will need to provide your own [custom TinyMCE
-plugins](https://docs.silverstripe.org/en/3.2/developer_guides/forms/field_types/htmleditorfield) or embed the files directly via HTML
-code.
+interface button. You will need to provide your own 
+[custom TinyMCE plugins](https://docs.silverstripe.org/en/3.2/developer_guides/forms/field_types/htmleditorfield) or 
+embed the files directly via HTML code.
 </div>
 
 ## Disable the media plugin
@@ -25,7 +25,9 @@ docs](https://docs.silverstripe.org/en/4/developer_guides/forms/field_types/html
 default editor installed by the `cwp` module:
 
 ```php
-HtmlEditorConfig::get('cwp')->disablePlugin('media');
+use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
+
+HTMLEditorConfig::get('cwp')->disablePlugins('media');
 ```
 
 Note the editor configuration we want to amend is "cwp" here, different from the default SilverStripe configuration
@@ -39,5 +41,6 @@ If you find out some attributes are still being removed by the editor, your can 
 Copy the `extended_valid_elements` option from `cwp/_config.php`, and amend it in your own `_config.php` to suit.
 
 ```php
-HtmlEditorConfig::get('cwp')->setOption('extended_valid_elements', '<your modified whitelist goes here>');
-```
+use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
+
+HTMLEditorConfig::get('cwp')->setOption('extended_valid_elements', '<your modified whitelist goes here>');```

--- a/docs/en/03_How_tos/custom_meta_tags.md
+++ b/docs/en/03_How_tos/custom_meta_tags.md
@@ -10,66 +10,75 @@ date of publication, etc.
 
 To do this, define the fields that you'd like specified on your page type and add the fields to the CMS view:
 
-	:::php
-	class Publication extends Page {
-		private static $db = array(
-			'MetaAuthor' => 'Varchar(255)',
-			'MetaCopyright' => 'Varchar(255)'
-		);
-		
-		...
-		
-		public function getCMSFields() {
-			$fields = parent::getCMSFields();
-			
-			$metaField = $fields->fieldByName('Root.Main.Metadata');
-			$metaField->push(TextareaField::create('MetaAuthor', 'Author'));
-			$metaField->push(TextareaField::create('MetaCopyright', 'Copyright'));
-			
-			return $fields;
-		}
-		
-		...
-	}
+```php
+class Publication extends Page 
+{
+    private static $db = [
+        'MetaAuthor' => 'Varchar(255)',
+        'MetaCopyright' => 'Varchar(255)'
+    ];
+    
+    ...
+    
+    public function getCMSFields() 
+    {
+        $fields = parent::getCMSFields();
+        
+        $metaField = $fields->fieldByName('Root.Main.Metadata');
+        $metaField->push(TextareaField::create('MetaAuthor', 'Author'));
+        $metaField->push(TextareaField::create('MetaCopyright', 'Copyright'));
+        
+        return $fields;
+    }
+    
+    ...
+}
+```
 
 If you run `dev/build?flush=all` and then browse to your page type, you'll see the fields you just defined in the
 expandable Meta Tags area on the main Page edit view.
 
 To display them, you'll need to override the MetaTags function in your page type:
 
-	:::php
-	class Publication extends Page {
-		...
-		
-		public function MetaTags($includeTitle = true) {
-			$tags = parent::MetaTags($includeTitle);
-			
-			if ($this->MetaAuthor) {
-				$tags .= "<meta name=\"author\" content=\"" . Convert::raw2att($this->MetaAuthor) . "\" />\n";
-			}
-			if ($this->MetaCopyright) {
-				$tags .= "<meta name=\"copyright\" content=\"" . Convert::raw2att($this->MetaCopyright) . "\" />\n";
-			}
-			
-			return $tags;
-		}
-	}
+```php
+class Publication extends Page 
+{
+    ...
+    
+    public function MetaTags($includeTitle = true) 
+    {
+        $tags = parent::MetaTags($includeTitle);
+        
+        if ($this->MetaAuthor) {
+            $tags .= "<meta name=\"author\" content=\"" . Convert::raw2att($this->MetaAuthor) . "\" />\n";
+        }
+        if ($this->MetaCopyright) {
+            $tags .= "<meta name=\"copyright\" content=\"" . Convert::raw2att($this->MetaCopyright) . "\" />\n";
+        }
+        
+        return $tags;
+    }
+}
+```
 
 That will take all of the tags that the `Page::MetaTags()` function defines and then add our custom ones on.
 
 We could automatically generate some of our own easily enough:
 
-	:::php
-	class Publication extends Page {
-		...
-		
-		public function MetaTags($includeTitle = true) {
-			$tags = $parent->MetaTags($includeTitle);
-			
-			...
-			
-			$tags .= "<meta name=\"last-modified\" content=\"" . date('Y-m-d@G:i:s T', strtotime($this->LastEdited)) . "\" />\n";
-			
-			return $tags;
-		}
-	}
+```php
+class Publication extends Page 
+{
+    ...
+    
+    public function MetaTags($includeTitle = true) 
+    {
+        $tags = $parent->MetaTags($includeTitle);
+        
+        ...
+        
+        $tags .= "<meta name=\"last-modified\" content=\"" . date('Y-m-d@G:i:s T', strtotime($this->LastEdited)) . "\" />\n";
+        
+        return $tags;
+    }
+}
+```

--- a/docs/en/03_How_tos/disable_default_workflow.md
+++ b/docs/en/03_How_tos/disable_default_workflow.md
@@ -8,6 +8,6 @@ When rebuilding your database, the default 'Two-step Workflow' is created by def
 In your `mysite/_config/config.yml` file, add the following:
 
 ```yml
-CwpWorkflowDefinitionExtension:
+CWP\CWP\Extensions\CwpWorkflowDefinitionExtension:
     create_default_workflow: false
 ```

--- a/docs/en/03_How_tos/disable_default_workflow.md
+++ b/docs/en/03_How_tos/disable_default_workflow.md
@@ -7,6 +7,7 @@ When rebuilding your database, the default 'Two-step Workflow' is created by def
 
 In your `mysite/_config/config.yml` file, add the following:
 
-	:::yml
-	CwpWorkflowDefinitionExtension:
-  		create_default_workflow: false
+```yml
+CwpWorkflowDefinitionExtension:
+    create_default_workflow: false
+```

--- a/docs/en/03_How_tos/exporting_content.md
+++ b/docs/en/03_How_tos/exporting_content.md
@@ -13,16 +13,17 @@ the module's documentation on [GitHub](https://github.com/silverstripe/silverstr
 To browse all instances of a DataObject make the call `GET /api/v1/(ClassName)` to the website. This will return an XML
 array in the format:
 
-	:::xml
-	<?xml version="1.0" encoding="UTF-8"?>
-	<ArrayList totalSize="10">
-		<Page href="http://mysite.com/api/v1/Page/1">
-			<Title>My Page</Title>
-			<Content><p>Hello, World!</p></Content
-			...
-		</Page>
-		...
-	</ArrayList>
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ArrayList totalSize="10">
+    <Page href="http://mysite.com/api/v1/Page/1">
+        <Title>My Page</Title>
+        <Content><p>Hello, World!</p></Content
+        ...
+    </Page>
+    ...
+</ArrayList>
+```
 
 As you might imagine, this could reach a very large size and take a long time to generate. To help with this, the API
 supports the `length` and `start` parameters which you can use to restrict the size of the block of content that you
@@ -45,13 +46,15 @@ static in the relevant classes and extend the array to include your new properti
 So if you have added
 
 ```php
+use SilverStripe\Assets\Image;
+
 class Page 
 {
-    static $db = [
+    private static $db = [
         'Author' => 'Varchar(255)'
     ];
-    static $has_one = [
-        'Thumbnail' => 'Image'
+    private static $has_one = [
+        'Thumbnail' => Image::class
     ];
 }
 ```
@@ -88,11 +91,11 @@ class SubmittedFormFieldExtension extends DataExtension
 
 and then added this to your `mysite/_config/config.yml`:
 
-```yml
-SubmittedForm:
+```yaml
+SilverStripe\UserForms\Model\Submission\SubmittedForm:
   extensions:
    - SubmittedFormExtension
-SubmittedFormField:
+SilverStripe\UserForms\Model\Submission\SubmittedFormField:
   extensions:
    - SubmittedFormFieldExtension
 ```
@@ -154,6 +157,6 @@ Out of the box the REST API is enabled giving access to already publicaly publis
 If you wish to disable this feature you can add the following into the `mysite/_config/config.yml`.
 
 ```yaml
-BasePage:
+CWP\CWP\PageTypes\BasePage:
   api_access: false
 ```

--- a/docs/en/03_How_tos/exporting_content.md
+++ b/docs/en/03_How_tos/exporting_content.md
@@ -42,23 +42,25 @@ The list of properties that is exported from `Page` is restricted by the static 
 If you have added any properties or relations that you wish to include in this list, you'll need to redefine this
 static in the relevant classes and extend the array to include your new properties.
 
-So if you have added:
+So if you have added
 
-	:::php
-	class Page {
-		static $db = array(
-			'Author' => 'Varchar(255)'
-		);
-		static $has_one = array(
-			'Thumbnail' => 'Image'
-		);
-	}
+```php
+class Page 
+{
+    static $db = [
+        'Author' => 'Varchar(255)'
+    ];
+    static $has_one = [
+        'Thumbnail' => 'Image'
+    ];
+}
+```
 
 then you might always want to add:
 
-	:::php
-	private static $api_access = array('Locale', 'URLSegment' ... 'ParentID', 'ID', 'Author', 'Thumbnail');
-
+```php
+private static $api_access = ['Locale', 'URLSegment' ... 'ParentID', 'ID', 'Author', 'Thumbnail'];
+```
 This will include the extra fields in the XML result.
 
 ## Exposing existing objects
@@ -70,25 +72,30 @@ hassles when it came to upgrading the module.
 
 A better way to do it is with extensions. If you created these two class definitions:
 
-	:::php
-	class SubmittedFormExtension extends DataExtension {
-		private static $api_access = true;
-	}
+```php
+class SubmittedFormExtension extends DataExtension 
+{
+    private static $api_access = true;
+}
+```
 
-	:::php
-	class SubmittedFormFieldExtension extends DataExtension {
-		private static $api_access = true;
-	}
+```php
+class SubmittedFormFieldExtension extends DataExtension 
+{
+    private static $api_access = true;
+}
+```
 
 and then added this to your `mysite/_config/config.yml`:
 
-	:::yml
-	SubmittedForm:
-	  extensions:
-	   - SubmittedFormExtension
-	SubmittedFormField:
-	  extensions:
-	   - SubmittedFormFieldExtension
+```yml
+SubmittedForm:
+  extensions:
+   - SubmittedFormExtension
+SubmittedFormField:
+  extensions:
+   - SubmittedFormFieldExtension
+```
 
 Now the `SubmittedForm` and `SubmittedFormField` classes are exposed to the REST API without modifying them directly.
 
@@ -102,11 +109,12 @@ field contains just the ID. The "Portrait" field is an empty node that contains 
 a request URL that just displays that one field, `id` which is the same ID that is in the "Portrait" field, and
 `linktype` which will be set to "has_one" in this case. An example is below:
 
-	:::xml
-	<Page>
-		<PortraitID>100</PortraitID>
-		<Portrait href="http://mysite.com/api/v1/Page/1/Portrait.xml" id="100" linktype="has_one"/>
-	</Page>
+```xml
+<Page>
+    <PortraitID>100</PortraitID>
+    <Portrait href="http://mysite.com/api/v1/Page/1/Portrait.xml" id="100" linktype="has_one"/>
+</Page>
+```
 
 If this is not appearing, check that you've exposed the relation as specified in the "Exposing new properties" section.
 
@@ -115,19 +123,20 @@ If this is not appearing, check that you've exposed the relation as specified in
 Has many relationships can only be viewed as both sides of the relationship are exposed to the REST API. They appear in
 the following format:
 
-	:::xml
-	<?xml version="1.0" encoding="UTF-8"?>
-	<ArrayList totalSize="10">
-		<Page href="http://mysite.com/api/v1/Page/1">
-			...
-			<RelatedPages href="http://mysite.com/api/v1/Page/1/RelatedPages.xml" linktype="has_many">
-				<Page href="http//mysite.com/api/v1/Page/2" id="2" />
-				...
-			</RelatedPages>
-			...
-		</Page>
-		...
-	</ArrayList>
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ArrayList totalSize="10">
+    <Page href="http://mysite.com/api/v1/Page/1">
+        ...
+        <RelatedPages href="http://mysite.com/api/v1/Page/1/RelatedPages.xml" linktype="has_many">
+            <Page href="http//mysite.com/api/v1/Page/2" id="2" />
+            ...
+        </RelatedPages>
+        ...
+    </Page>
+    ...
+</ArrayList>
+```
 
 If you browse to the location in the `href` attribute (`http://mysite.com/api/v1/Page/1/RelatedPages.xml` in this case)
 then you'll get the same content but without the additional attributes of the page.

--- a/docs/en/03_How_tos/external_http_requests_with_proxy.md
+++ b/docs/en/03_How_tos/external_http_requests_with_proxy.md
@@ -35,10 +35,10 @@ the development machine:
 
 ```php
 // use proxy if the environment file has a proxy definition
-if(defined('SS_OUTBOUND_PROXY') && defined('SS_OUTBOUND_PROXY_PORT')) {
+if(Environment::getEnv('SS_OUTBOUND_PROXY') && Environment::getEnv('SS_OUTBOUND_PROXY_PORT')) {
     $context = stream_context_create([
         'http' => [
-            'proxy' => sprintf('tcp://%s:%s', SS_OUTBOUND_PROXY, SS_OUTBOUND_PROXY_PORT),
+            'proxy' => sprintf('tcp://%s:%s', Environment::getEnv('SS_OUTBOUND_PROXY'), Environment::getEnv('SS_OUTBOUND_PROXY_PORT')),
             'request_fulluri' => true
         ]
     ]);
@@ -63,12 +63,12 @@ echo curl_exec($ch);
 
 You can also disable automatic proxy configuration globally by putting the following in one of your config files:
 
-```yml
+```yaml
 ---
 Name: mysiteconfig
 After: '#cwpcoreconfig'
 ---
-CwpInitialisationFilter:
+CWP\Core\Control\InitialisationMiddleware:
   egress_proxy_default_enabled: false
 ```
 
@@ -78,7 +78,7 @@ It's possible to exclude just some domains from being forced through the proxy i
 desirable. By default this is used by the Solr and Docvert services internal to CWP. The configuration can be appended
 to as follows:
 
-```yml
+```yaml
 ---
 Name: mysiteconfig
 After: '#cwpcoreconfig'

--- a/docs/en/03_How_tos/external_http_requests_with_proxy.md
+++ b/docs/en/03_How_tos/external_http_requests_with_proxy.md
@@ -22,51 +22,55 @@ You can look up the implementation details in the `CwpInitialisationFilter` in t
 
 ## Stream-based requests
 
-Stream-based requests however will need extra manual configuration. For example the following will not work, resulting
+Stream-based requests however will need extra manual configuration. For example, the following will not work, resulting
 in a "Connection refused" error:
 
-	:::php
-	echo file_get_contents('http://www.silverstripe.org/blog/rss');
+```php
+echo file_get_contents('http://www.silverstripe.org/blog/rss');
+```
 
 We can modify it to use the proxy. Proxy URL on CWP environments is provided via `SS_OUTBOUND_PROXY` define, and port is
 provided via `SS_OUTBOUND_PROXY_PORT`. We can check for the existence of these so we are not forced to use the proxy on
 the development machine:
 
-	:::php
-	// use proxy if the environment file has a proxy definition
-	if(defined('SS_OUTBOUND_PROXY') && defined('SS_OUTBOUND_PROXY_PORT')) {
-		$context = stream_context_create(array(
-			'http' => array(
-				'proxy' => sprintf('tcp://%s:%s', SS_OUTBOUND_PROXY, SS_OUTBOUND_PROXY_PORT),
-				'request_fulluri' => true
-			)
-		));
-		
-		echo file_get_contents('http://www.silverstripe.org/blog/rss', false, $context);
-	} else {
-		echo file_get_contents('http://www.silverstripe.org/blog/rss');
-	}
+```php
+// use proxy if the environment file has a proxy definition
+if(defined('SS_OUTBOUND_PROXY') && defined('SS_OUTBOUND_PROXY_PORT')) {
+    $context = stream_context_create([
+        'http' => [
+            'proxy' => sprintf('tcp://%s:%s', SS_OUTBOUND_PROXY, SS_OUTBOUND_PROXY_PORT),
+            'request_fulluri' => true
+        ]
+    ]);
+    
+    echo file_get_contents('http://www.silverstripe.org/blog/rss', false, $context);
+} else {
+    echo file_get_contents('http://www.silverstripe.org/blog/rss');
+}
+```
 
 ## Disabling egress proxy
 
 In some situations you might want to disable the proxy. You can do it by customising curl configuration per request:
 
-	:::php
-	$ch = curl_init();
-	curl_setopt($ch, CURLOPT_PROXY, false);
-	curl_setopt($ch, CURLOPT_PROXYPORT, false);
-	curl_setopt($ch, CURLOPT_URL, '<non-proxied-URL>');
-	echo curl_exec($ch);
+```php
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_PROXY, false);
+curl_setopt($ch, CURLOPT_PROXYPORT, false);
+curl_setopt($ch, CURLOPT_URL, '<non-proxied-URL>');
+echo curl_exec($ch);
+```
 
 You can also disable automatic proxy configuration globally by putting the following in one of your config files:
 
-	:::yml
-	---
-	Name: mysiteconfig
-	After: '#cwpcoreconfig'
-	---
-	CwpInitialisationFilter:
-	  egress_proxy_default_enabled: false
+```yml
+---
+Name: mysiteconfig
+After: '#cwpcoreconfig'
+---
+CwpInitialisationFilter:
+  egress_proxy_default_enabled: false
+```
 
 ## Excluding domains from egress proxy
 
@@ -74,11 +78,12 @@ It's possible to exclude just some domains from being forced through the proxy i
 desirable. By default this is used by the Solr and Docvert services internal to CWP. The configuration can be appended
 to as follows:
 
-	:::yml
-	---
-	Name: mysiteconfig
-	After: '#cwpcoreconfig'
-	---
-	CwpInitialisationFilter:
-	  egress_proxy_exclude_domains:
-	    - somewhere.cwp.govt.nz
+```yml
+---
+Name: mysiteconfig
+After: '#cwpcoreconfig'
+---
+CwpInitialisationFilter:
+  egress_proxy_exclude_domains:
+    - somewhere.cwp.govt.nz
+```

--- a/docs/en/03_How_tos/firewall_ports.md
+++ b/docs/en/03_How_tos/firewall_ports.md
@@ -9,7 +9,7 @@ These are:
  * *.packagist.org - ports 80, 443 (Composer uses this to determine which code to install)
  * *.cwp.govt.nz - ports 80, 443 (CWP GitLab, Deployment tools, UAT servers etc)
 
-* refers to that the firewall should allow access to all subdomain websites for the domain name (a "wildcard"). 
+\* refers to that the firewall should allow access to all subdomain websites for the domain name (a "wildcard"). 
 For example, CWP has gitlab.cwp.govt.nz, deploy.cwp.govt.nz  etc.
 
-You may need to talk internally to your Netowrk or ICT team to ensure you can access these ports and sites.
+You may need to talk internally to your Network or ICT team to ensure you can access these ports and sites.

--- a/docs/en/03_How_tos/install_sample_project_data.md
+++ b/docs/en/03_How_tos/install_sample_project_data.md
@@ -3,7 +3,7 @@ summary: How to install sample project data
 
 # Introduction
 
-When first starting with a CWP project you may find it useful to install some sample data. The `cwp/cwp` module come with a task you can run which will install some pre-defined sample data such as page content and a "contact us" [userform](https://github.com/silverstripe/silverstripe-userforms).
+When first starting with a CWP project you may find it useful to install some sample data. The `cwp/cwp` module comes with a task you can run which will install some pre-defined sample data such as page content and a "contact us" [userform](https://github.com/silverstripe/silverstripe-userforms).
 
 ## Running the task
 
@@ -30,4 +30,4 @@ An option for testing a number of features (including form fields, sample member
 composer require silverstripe/frameworktest
 ```
 
-Please see the module's documentation (linked above) for information on how to configure and use it.
+Please see [the module's documentation](https://github.com/silverstripe/silverstripe-frameworktest/blob/master/README.md) for information on how to configure and use it.

--- a/docs/en/03_How_tos/last_modified_date_on_pages.md
+++ b/docs/en/03_How_tos/last_modified_date_on_pages.md
@@ -5,10 +5,8 @@ summary: How to display the last modified date on a website page.
 
 On all pages of a CWP site, there is some text in the footer of the page. e.g. "Last modified: 1st April 2014".
 
-If you are using the default theme, the `Footer.ss` template will include `LastEdited.ss`. It uses the `$LastEdited`
-template variable for this date.
-
-If you are using the starter or Wātea themes this field is included from the `PageUtilities.ss` template, and is defined in `LastModified.ss`.
+If you are using the CWP Starter or Wātea themes, the `PageUtilities.ss` template will include `LastEdited.ss`. It uses the `$LastEdited`
+template variable for this date and is defined in `LastModified.ss`.
 
 If you're viewing the draft version of a page (e.g. preview of page while editing in the CMS),
 the "Last modified" date will be the date the draft was last saved.
@@ -21,7 +19,7 @@ date will become the date the page is published on that scheduled date.
 
 Each page in the CMS will have an option in the Settings tab to hide the "page utilities".
 
-In the starter and Wātea themes this is the footer bar which contains both the last modified date and the export and share links.
+In the CWP Starter and Wātea themes this is the footer bar which contains both the last modified date and the export and share links.
 
 You can add conditions around the `$ShowPageUtilities` variable in your page templates to control this behaviour, for example:
 

--- a/docs/en/03_How_tos/mail_spf.md
+++ b/docs/en/03_How_tos/mail_spf.md
@@ -3,7 +3,7 @@ summary: What to add in your DNS SPF record to ensure mail deliverability when s
 
 # Mail deliverability
 
-If you wish to send mail from your stack as coming from your own domain, for example From: info@example.com,
+If you wish to send mail from your stack as coming from your own domain, for example from info@example.com,
 the receiving mail server might mark your emails as SPAM unless you make the following changes.
 
 The mail server will typically look up your DNS information and look for SPF to check legitimacy.
@@ -15,5 +15,7 @@ include:cwp.govt.nz
 
 to the SPF record, this will inherit the CWP configuration.
 
-Please feel free to make a General Support request if you need any help with this configuration.
+Please feel free to create a support ticket in the [CWP Service Desk](https://www.cwp.govt.nz/service-desk/new-request/), if you need any help with this configuration.
+
+
 

--- a/docs/en/03_How_tos/maintenance_screen.md
+++ b/docs/en/03_How_tos/maintenance_screen.md
@@ -14,16 +14,19 @@ the appropriate error codes. Setup the following (as below) with the codes 500 a
 
 These pages will be displayed to the user in the following situations:
 
-## During server error or outage
+* [During server error or outage](#during-server-error-or-outage-2)
+* [During Deployment](#during-deployment-2)
+
+## Error pages during server error or outage
 
 In the event that the destination environment is completely unavailable, the error-500.html page will be served directly
-from the gateway.  This will also respond to most general server errors.
+from the gateway. This will also respond to most general server errors.
 
 This page and its assets will be updated regularly to ensure that a cached backup of all necessary files are available.
 
 Note that this page is normally created by default during install.
 
-## During Deployment
+## Error pages during Deployment
 
 During the course of certain deployment activities Deploynaut will display the error-503.html page for the duration
 of the process.

--- a/docs/en/03_How_tos/maintenance_screen.md
+++ b/docs/en/03_How_tos/maintenance_screen.md
@@ -28,15 +28,15 @@ Note that this page is normally created by default during install.
 
 ## Error pages during Deployment
 
-During the course of certain deployment activities Deploynaut will display the error-503.html page for the duration
+During the course of certain deployment activities Dashboard will display the error-503.html page for the duration
 of the process.
 
 ![Default maintenance screen](/_images/default-maintenance-screen.jpg)
 
-From the technical perspective, Deploynaut creates temporary `.htaccess` and `maintenance.html` files. It assumes that
+From the technical perspective, Dashboard creates temporary `.htaccess` and `maintenance.html` files. It assumes that
 the codebase comes with `.htaccess`, so this is renamed and stored for later retrieval. Websites must not create their
 own `maintenance.html` however as this will cause deployments to fail or the file to be destroyed. The maintenance page
-will either be uploaded from Deploynaut template, or created from `assets/error-503.html` (if available).
+will either be uploaded from Dashboard template, or created from `assets/error-503.html` (if available).
 
 `.htaccess` is then used to redirect all requests to the maintenance page. After the process has completed (or failed)
 the former `.htaccess` is restored and `maintenance.html` removed.

--- a/docs/en/03_How_tos/migrate_git_repo_to_github.md
+++ b/docs/en/03_How_tos/migrate_git_repo_to_github.md
@@ -12,13 +12,13 @@ Please ensure the below considerations are thought through prior to moving your 
 * Repeated outages caused by custom code changes where CWP support staff have no access, may result in the disabling of monitoring systems until resolution of the underlying issue.
 
 ## Preparation
-1. [Create the GitHub private or public repository](https://help.github.com/articles/create-a-repo/) Create the GitHub private or public repository to be associated with CWP instance.
-2. [Locate your Deploy public key in the CWP Dashboard](https://www.cwp.govt.nz/developer-docs/en/working_with_projects/deploying_code/#deploy-key-2)
-3. Allow access to CWP systems by adding the above deploy key to the repository [starting at setup step2](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys)
+1. [Create the GitHub private or public repository](https://help.github.com/articles/create-a-repo/) Create the GitHub private or public repository to be associated with the CWP instance.
+2. [Locate your Deploy public key in the CWP Dashboard](https://www.cwp.govt.nz/developer-docs/en/working_with_projects/deploying_code/#deploy-key-2).
+3. Allow access to CWP systems by adding the above deploy key to the repository [starting at Setup step 2](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys).
 
 ## Requesting repository migration to GitHub
-Currently migration is managed through the CWP service desk.
+Currently migration is managed through the CWP Service Desk.
 
-Create a new CWP service desk request to [Move Git repo to self managed GitHub Git repo](https://www.cwp.govt.nz/service-desk/requests/?target=set_project.php%3Fproject_id%3D23%3B59%26redirect_bug%3D1)
+Create a new CWP Service Desk request to [move a Git repository to a self managed GitHub Git repository](https://www.cwp.govt.nz/service-desk/requests/?target=set_project.php%3Fproject_id%3D23%3B59%26redirect_bug%3D1).
 
 Once the instance manager has approved the request to migrate the repository to GitHub, CWP support staff will update the deployment services to reference the external repository.

--- a/docs/en/03_How_tos/preparing_your_site_for_active_dr.md
+++ b/docs/en/03_How_tos/preparing_your_site_for_active_dr.md
@@ -3,15 +3,15 @@ summary: How to Prepare your website to use Active DR infrastructure.
 
 # Preparing your site for Active Disaster Recovery
 
-This guide describes the steps needed to get your site ready for Active Disaster Recovery stacks. None of these
+This guide describes the steps needed to get your site ready for Active Disaster Recovery (DR) stacks. None of these
 modifications are needed on regular stacks.
 
 Active DR stacks have two properties:
 
- * They are load-balanced: the traffic is served from two datacentres, increasing the maximum potential capacity of the
+ * They are load-balanced. The traffic is served from two data centres, increasing the maximum potential capacity of the
  stack.
- * They are highly-available: if one datacentre / node exhibits a problem and is not reachable, or emits 5xx HTTP status
- code, this node will be pulled out of the pool and all traffic will be redirected to the other datacentre.
+ * They are highly-available. If one data centre / node exhibits a problem and is not reachable, or emits 5xx HTTP status
+ code, this node will be pulled out of the pool and all traffic will be redirected to the other data centre.
 
 
 Your custom domains will be actively load balanced between the two nodes. *.cwp.govt.nz domains are not load balanced and point to either the Wellington or Auckland node. We supply two domains for Active DR environments for both UAT and PROD to help debug issues:
@@ -19,8 +19,8 @@ Your custom domains will be actively load balanced between the two nodes. *.cwp.
  * stack-dr.cwp.govt.nz - points to Auckland
 
 
-<div class="warning" markdown='1'>
-In other words: we cannot make your site highly-available if your production domain is not pointing to CWP (i.e. your
+<div class="alert alert-warning" markdown='1'>
+In other words, we can't make your site highly-available if your production domain is not pointing to CWP (i.e. your
 site is not live).  Additionally, accessing your site at any time through the "cwp.govt.nz" domain will not exhibit the
 highly-available property.
 </div>
@@ -28,29 +28,33 @@ highly-available property.
 The following chapters provide information on the required changes to your code to ensure the site works correctly with
 Active Disaster Recovery.
 
-## Provide SSL certificate for your primary domain
+## Provide an SSL certificate for your primary domain
 
 You will need to provide us with an SSL certificate for your primary domain so HTTPS requests
 are load-balanced between servers. We can also organise the SSL certificate for you if you prefer.
 
 ## Shared sessions across servers
 
-If you are running at least version 1.0.4 of the [cwp-core](https://gitlab.cwp.govt.nz/cwp/cwp-core) module, shared
+If you are running at least version 1.0.4 of the [cwp-core](https://github.com/silverstripe/cwp-core) module, shared
 sessions have already been configured. You can skip this step.
 
-Otherwise, if you running an earlier version, please follow these steps:
+Otherwise, if you are running an earlier version, please follow these steps:
 
-### 1. Install the hybridsessions module
+### 1. Install the Hybrid Sessions module
 
-	composer require "silverstripe/hybridsessions:*"
+```
+composer require "silverstripe/hybridsessions:*"
+```
 
 ### 2. Configure the module
 
 In your `mysite/_config.php` file, add this configuration:
 
-	if(defined('CWP_INSTANCE_DR_TYPE') && CWP_INSTANCE_DR_TYPE === 'active'
-		&& defined('SS_SESSION_KEY') && class_exists('HybridSessionStore')
-		&& !HybridSessionStore::is_enabled()
-	) {
-		HybridSessionStore::init(SS_SESSION_KEY);
-	}
+```
+if(defined('CWP_INSTANCE_DR_TYPE') && CWP_INSTANCE_DR_TYPE === 'active'
+    && defined('SS_SESSION_KEY') && class_exists('HybridSessionStore')
+    && !HybridSessionStore::is_enabled()
+) {
+    HybridSessionStore::init(SS_SESSION_KEY);
+}
+```

--- a/docs/en/03_How_tos/preparing_your_site_for_active_dr.md
+++ b/docs/en/03_How_tos/preparing_your_site_for_active_dr.md
@@ -11,7 +11,7 @@ Active DR stacks have two properties:
  * They are load-balanced. The traffic is served from two data centres, increasing the maximum potential capacity of the
  stack.
  * They are highly-available. If one data centre / node exhibits a problem and is not reachable, or emits 5xx HTTP status
- code, this node will be pulled out of the pool and all traffic will be redirected to the other data centre.
+ codes, this node will be pulled out of the pool and all traffic will be redirected to the other data centre.
 
 
 Your custom domains will be actively load balanced between the two nodes. *.cwp.govt.nz domains are not load balanced and point to either the Wellington or Auckland node. We supply two domains for Active DR environments for both UAT and PROD to help debug issues:
@@ -50,11 +50,13 @@ composer require "silverstripe/hybridsessions:*"
 
 In your `mysite/_config.php` file, add this configuration:
 
-```
-if(defined('CWP_INSTANCE_DR_TYPE') && CWP_INSTANCE_DR_TYPE === 'active'
-    && defined('SS_SESSION_KEY') && class_exists('HybridSessionStore')
-    && !HybridSessionStore::is_enabled()
+```php
+// Automatically configure session key for activedr with hybridsessions module
+if (Environment::getEnv('CWP_INSTANCE_DR_TYPE')
+    && Environment::getEnv('CWP_INSTANCE_DR_TYPE') === 'active'
+    && Environment::getEnv('SS_SESSION_KEY')
+    && class_exists(HybridSession::class)
 ) {
-    HybridSessionStore::init(SS_SESSION_KEY);
+    HybridSession::init(Environment::getEnv('SS_SESSION_KEY'));
 }
 ```

--- a/docs/en/03_How_tos/redirections.md
+++ b/docs/en/03_How_tos/redirections.md
@@ -4,9 +4,9 @@ summary: How to implement a redirect on your stack.
 # Introduction
 
 There's a few ways developers can implement redirections on their CWP stacks:
-- in the `.htaccess` file
-- within the site's `_config.php`
-- with a module
+- In the `.htaccess` file
+- Within the site's `_config.php`
+- With a module
 
 ## .htaccess
 

--- a/docs/en/03_How_tos/supporting_large_numbers_of_files.md
+++ b/docs/en/03_How_tos/supporting_large_numbers_of_files.md
@@ -22,7 +22,7 @@ YML configuration to replace the existing class via dependency injection.
 ```php
 <?php
 
-use SilverStripe\AssetAdmin;
+use SilverStripe\AssetAdmin\Controller\AssetAdmin;
 
 class SimpleAssetAdmin extends AssetAdmin
 {

--- a/docs/en/03_How_tos/supporting_large_numbers_of_files.md
+++ b/docs/en/03_How_tos/supporting_large_numbers_of_files.md
@@ -21,8 +21,13 @@ YML configuration to replace the existing class via dependency injection.
 
 ```php
 <?php
-class SimpleAssetAdmin extends AssetAdmin {
-	public function getEditForm($id = null, $fields = null) {
+
+use SilverStripe\AssetAdmin;
+
+class SimpleAssetAdmin extends AssetAdmin
+{
+	public function getEditForm($id = null, $fields = null) 
+	{
 		$form = parent::getEditForm($id, $fields);
 		$form->Fields()->removeByName('TreeView');
 		return $form;

--- a/docs/en/03_How_tos/use_alternate_module_version.md
+++ b/docs/en/03_How_tos/use_alternate_module_version.md
@@ -13,10 +13,10 @@ For example, if we wanted to use the `dev-master` version of the `silverstripe-a
 following statement into the `require` section of our project `composer.json`:
 
 ```
-"silverstripe/advancedworkflow": "dev-master as 4.0.1"
+"symbiote/silverstripe-advancedworkflow": "dev-master as 4.0.1"
 ```
 
-This will satisfy the `"silverstripe/advancedworkflow": "4.0.1"` requirement embedded in the recipe.
+This will satisfy the `"silverstripe/advancedworkflow": "4.0.1"` requirement embedded in the [SilverStripe collaboration recipe](https://github.com/silverstripe/recipe-collaboration).
 
 Please note that generally you should only do this if you are sure about the impact of switching the module version, and
 after you have tested it yourself for regressions with other modules.

--- a/docs/en/03_How_tos/use_alternate_module_version.md
+++ b/docs/en/03_How_tos/use_alternate_module_version.md
@@ -9,12 +9,14 @@ example is if you contribute to the upstream repository, and you would like to u
 To do this we can use a composer's *inline alias*. This is a way of specifying that our desired version is satisfying
 some other requirement (in this case coming from the recipe).
 
-For example if we wanted to use the `dev-master` version of the `silverstripe-advancedworkflow` module, we would add the
+For example, if we wanted to use the `dev-master` version of the `silverstripe-advancedworkflow` module, we would add the
 following statement into the `require` section of our project `composer.json`:
 
-	"silverstripe/advancedworkflow": "dev-master as 3.0.1"
+```
+"silverstripe/advancedworkflow": "dev-master as 4.0.1"
+```
 
-This will satisfy the `"silverstripe/advancedworkflow": "3.0.1"` requirement embedded in the recipe.
+This will satisfy the `"silverstripe/advancedworkflow": "4.0.1"` requirement embedded in the recipe.
 
 Please note that generally you should only do this if you are sure about the impact of switching the module version, and
 after you have tested it yourself for regressions with other modules.

--- a/docs/en/03_How_tos/using_content_migration_tools.md
+++ b/docs/en/03_How_tos/using_content_migration_tools.md
@@ -1,11 +1,11 @@
 title: Using content migration tools
-summary: How to use the available content mogration tools for SilverStripe CMS.
+summary: How to use the available content migration tools for SilverStripe CMS.
 
 # Using content migration tools
 
 The Common Web Platform provides migration tools to assist with migrating data and content from other platforms. Currently the tools support:
 
-* HTML-based spidering and scraping of a website.
+* HTML-based crawling and scraping of a website.
 * Connecting directly to a website running the Drupal content management system.
 
 The migration tools are extendable and can be adapted to connect with other software systems not currently supported. 
@@ -18,7 +18,7 @@ HTML
 
 Drupal
 
-* See [http://www.silverstripe.org/drupal-connector-module/](http://www.silverstripe.org/drupal-connector-module/) and  [https://github.com/silverstripe-droptables/silverstripe-drupal-connector](https://github.com/silverstripe-droptables/silverstripe-drupal-connector)
+* See [http://www.silverstripe.org/drupal-connector-module/](http://www.silverstripe.org/drupal-connector-module/) and [https://github.com/silverstripe-droptables/silverstripe-drupal-connector](https://github.com/silverstripe-droptables/silverstripe-drupal-connector)
 
 A screenshot of the HTML importer is shown here:
 

--- a/docs/en/04_Performance_Guide/00_Performance_Testing.md
+++ b/docs/en/04_Performance_Guide/00_Performance_Testing.md
@@ -9,7 +9,7 @@ If you are migrating an existing site, analysis of the access logs will help you
 such as the most commonly accessed pages, sections, or user behaviours. A great tool for a visual representation of your
 log data is [GoAccess](https://goaccess.io/).
 
-<div class='warning'>
+<div class='alert alert-warning'>
 Be wary of using Google Analytics as a source of your most-hit URLs - they don't include bot visitors, which can end up
 skewing your traffic a long way towards URLs that you would not expect. This is also why you should take your pageviews
 statistic with a grain of salt if it comes from Google Analytics - access logs are the truest record.
@@ -62,10 +62,10 @@ The [SilverStripe DebugBar](https://github.com/lekoala/silverstripe-debugbar) mo
 
 In addition to local testing, you want to get real world performance samples on the CWP infrastructure early and
 frequently. While you can run low concurrency tests with a handful of users unannounced, please contact the
-[CWP Helpdesk](https://www.cwp.govt.nz/service-desk/new-request/) before testing with high request volumes - this allows
+[CWP Service Desk](https://www.cwp.govt.nz/service-desk/new-request/) before testing with high request volumes - this allows
 the team to configure the site to expect unusual traffic peaks, whitelist testing IP addresses, and generally not panic
 if the site begins to show signs of struggle. You should do this at least three days before you intend to test.
-Generally this will performed by a specialist testing company.
+Generally this will be performed by a specialist testing company.
 
 ## Next
 

--- a/docs/en/04_Performance_Guide/01_Caching.md
+++ b/docs/en/04_Performance_Guide/01_Caching.md
@@ -57,7 +57,7 @@ The cache stores the serialised root element. If a cache entry already exists, w
 of doing the expensive calculation again. Each cache has a default expiry time which can be customised.
 
 ```php
-function findRootParent() 
+public function findRootParent() 
 {
 	$cache = SS_Cache::factory('rootparents');
 	if (!$cache->test($this->ID)) {

--- a/docs/en/04_Performance_Guide/01_Caching.md
+++ b/docs/en/04_Performance_Guide/01_Caching.md
@@ -57,11 +57,12 @@ The cache stores the serialised root element. If a cache entry already exists, w
 of doing the expensive calculation again. Each cache has a default expiry time which can be customised.
 
 ```php
-function findRootParent() {
+function findRootParent() 
+{
 	$cache = SS_Cache::factory('rootparents');
 	if (!$cache->test($this->ID)) {
 		$parent = $this;
-		whilst ($parent->exists()) {
+		while ($parent->exists()) {
 			$lastParent = $parent;
 			$parent = $parent->Parent();
 		}
@@ -71,8 +72,8 @@ function findRootParent() {
 }
 ```
 
-Read more about [Object Caching](https://docs.silverstripe.org/en/3/developer_guides/performance/caching/)
-on doc.silverstripe.org.
+Read more about [Object Caching](https://docs.silverstripe.org/en/4/developer_guides/performance/caching/)
+on docs.silverstripe.org.
 
 ## Template Caching ("Partial Caching")
 
@@ -110,7 +111,7 @@ you are only executing this expensive calculation every 10 minutes
 (the default cache lifetime). More sophisticated cache logic is possible.
 
 Read more about
-[Partial Caching](https://docs.silverstripe.org/en/3/developer_guides/performance/partial_caching/) on doc.silverstripe.org
+[Partial Caching](https://docs.silverstripe.org/en/4/developer_guides/performance/partial_caching/) on docs.silverstripe.org
 
 
 ## Static caching on the server
@@ -123,9 +124,9 @@ without waiting for an intermediary cache layer to expire. Similarly to HTTP Cac
 this approach relies on sending the same response to all of your visitors.
 
 A common way to implement static caching in SilverStripe is the
-[staticpublishqueue module](https://github.com/silverstripe/silverstripe-staticpublishqueue).
+[Static Publisher with Queue module](https://github.com/silverstripe/silverstripe-staticpublishqueue).
 With this module, you'll need to define dependencies between pages
-to ensure accuracy, making Static caching a relatively advanced technique.
+to ensure accuracy, making static caching a relatively advanced technique.
 
 This approach can also be combined with HTTP Caching for maximum effect:
 In this scenario, the generated HTML files are further cached in intermediary layers.
@@ -134,7 +135,7 @@ In this scenario, the generated HTML files are further cached in intermediary la
 Your site will only be suitable for static caching if
 there is no dynamic content on the site, including user login and forms.
 
-If you have a dynamic area of your site but still wish to use some static caching, you can statically cache parts of
+If you have a dynamic area of your site, but still wish to use some static caching, you can statically cache parts of
 your site and leave other parts uncached. You could investigate caching your most popular or busy pages while leaving
 the others to be generated on request. This is the most common implementation of static caching.
 
@@ -144,8 +145,8 @@ Both HTTP Caching and Static Caching rely on serving the same content to all vis
 If your website is mostly cacheable, but you have minor dynamic behaviour such as a "logged in" menu indicator,
 you can use the best of both worlds: Generate static HTML content once for all visitors,
 but run the response through a lightweight SilverStripe PHP request in order to add dynamic bits to the response.
-You can do this with the [staticpublishqueue module](https://github.com/silverstripe/silverstripe-staticpublishqueue)
-module as well as [markguinn/silverstripe-livepub](https://github.com/markguinn/silverstripe-livepub).
+You can do this with the [Static Publisher with Queue module](https://github.com/silverstripe/silverstripe-staticpublishqueue)
+module as well as the [LivePub module](https://github.com/markguinn/silverstripe-livepub).
 
 ## Next
 

--- a/docs/en/04_Performance_Guide/02_HTTP_Caching.md
+++ b/docs/en/04_Performance_Guide/02_HTTP_Caching.md
@@ -4,7 +4,7 @@ summary: Improve performance with HTTP caching layers built into CWP
 # HTTP Caching
 
 This page describes how you can use **Transparent HTTP caches** to speed up your website.
-These caches are a black-box solution which can be interacted with through the HTTP headers
+These caches are a black-box solution which can be interacted with through the HTTP headers.
 They're always-on and external to the instances.
 
 Most caching is disabled by default in CWP to avoid accidental information leaks.
@@ -18,24 +18,31 @@ CWP is equipped with two transparent cache systems: A *Local Cache Layer* in the
 
 All instance responses are analysed and some of them may be cached to increase performance. Their behaviour can be controlled:
 
-* through the response headers configured in your code (see the "Configuration via headers" chapter)
-* if you opted for the Premium Managed Service, through Incapsula configuration panel (see the "Configuration via Incapsula" chapter)
+* through the response headers configured in your code (see the ["Configuration via headers" chapter](#configuration-via-headers-2))
+* if you opted for the [Premium Managed Service](https://www.cwp.govt.nz/features/optional-extras/), through Incapsula configuration panel (see the ["Configuration via Incapsula" chapter](#configuration-via-incapsula-2))
 
-The default recipe is configured conservatively to protect the data. This means SilverStripe Framework responses will not be cached at all. All other resources (static files) will be cached for a short period of time (see below for details).
+The default recipes are configured conservatively to protect the data. This means SilverStripe Framework responses will not be cached at all. All other resources (static files) will be cached for a short period of time (see below for details).
 
 ### Content Security
 
-All caches, if misconfigured, are in danger of leaking user-specific or confidential information to non-privileged visitors. To avoid this, the default recipe will produce uncache-able responses even if it means less cache utilisation. Caching needs to be considered on a site-by-site basis.
+All caches, if misconfigured, are in danger of leaking user-specific or confidential information to non-privileged visitors. 
+To avoid this, the default recipes will produce non-cacheable responses even if it means less cache utilisation. 
+Caching needs to be considered on a site-by-site basis.
 
-Here is an example of how things could go wrong: Let's assume a site serves "Hello, (FirstName)" snippet to logged-in users only. Further assume a cache is misconfigured, and a logged-in user "John" requests a page: the cache retains the response containing the "Hello John" string. Now, if user Steve comes along he will be served the cached version of the page erroneously containing "Hello John" string (unless the cache times out before his arrival).
+Here is an example of how things could go wrong: Let's assume a site serves "Hello, (FirstName)" snippet to logged-in users only. 
+Further assume a cache is misconfigured, and a logged-in user "John" requests a page: the cache retains the response containing the "Hello John" string. 
+Now, if user Steve comes along he will be served the cached version of the page erroneously containing "Hello John" string (unless the cache times out before his arrival).
 
-It's easy to extend this example to more significant user details - addresses, private messages, personal records, etc. We will show below how to avoid this kind of issues, and always highlight secure defaults.
+It's easy to extend this example to more significant user details - addresses, private messages, personal records, etc. 
+We will show below how to avoid this kind of issues, and always highlight secure defaults.
 
 ### Possible performance gains
 
-A simplistic test conducted by the CWP team has shown the CDN can sustain 400 resource requests per second in certain configurations without impacting the instance considerably. In our case the test harness turned out to be the bottleneck and the top limit was not established.
+A simplistic test conducted by the CWP team has shown the CDN can sustain 400 resource requests per second in certain configurations without impacting the instance considerably. 
+In our case the test harness turned out to be the bottleneck and the top limit was not established.
 
-This test should not be treated as representative for all CWP sites as it depends on many variables such as site's architecture, configuration and traffic profile. Agencies are urged to carry out their own load testing to determine the exact performance profile of their site.
+This test should not be treated as representative for all CWP sites as it depends on many variables such as site's architecture, configuration and traffic profile. 
+Agencies are urged to carry out their own load testing to determine the exact performance profile of their site.
 
 Also see the *"Can I leverage caching so that I can fit a large site on a small instance?"* question in the 
 [FAQ below](#faq-2).
@@ -47,12 +54,13 @@ To help explain how actively the content could be cached on CWP let's split the 
 | Cache level | Caches used | Potential response times | Instance load |
 | - | - | - | - |
 | None | - | >100ms | Full |
-| Light | Local | 10 - 100ms for NZ users, more for overseas users due to the transmission latency. | Reduced in proportion to the amount of cache-able responses and their cache duration. |
+| Light | Local | 10 - 100ms for NZ users, more for overseas users due to the transmission latency. | Reduced in proportion to the amount of cacheable responses and their cache duration. |
 | Full | Local + CDN | 10-100ms for all users regardless of location. | Same as the "Light" cache level. |
 
 ### Configuration via headers
 
-Your best approach in controlling the caching behaviour is setting your response headers in accordance with the [RFC-2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html). This will ensure that all caches on the way of the response will be able to make reasonable decisions. This includes CWP's Local Cache, the CDN (Incapsula), any other public proxies (such as corporate gateways) and the browser cache.
+Your best approach in controlling the caching behaviour is setting your response headers in accordance with the [RFC-2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html). 
+This will ensure that all caches on the way of the response will be able to make reasonable decisions. This includes CWP's Local Cache, the CDN (Incapsula), any other public proxies (such as corporate gateways) and the browser cache.
 
 We will now explain some simple techniques on how to increase your cache utilisation. Let's have a look at the mapping between the cache levels and specific response headers.
 
@@ -62,8 +70,8 @@ We will now explain some simple techniques on how to increase your cache utilisa
 | Light | "max-age=X" | "Cookie, […]" | all |
 | Full | "max-age=X" | _none_ or "Accept-Encoding" | non-varying* |
 
-The easiest way improve caching on your dynamic responses is to use the [controllerpolicy](https://github.com/silverstripe-labs/silverstripe-controllerpolicy) module. It allows you to customise the response headers per `Controller` without the need to modify any PHP code.
-For deeper customisations, you also [set HTTP Cache headers directly](https://docs.silverstripe.org/en/3/developer_guides/performance/http_cache_headers/).
+The easiest way improve caching on your dynamic responses is to use the [Controller Policy module](https://github.com/silverstripe-labs/silverstripe-controllerpolicy). It allows you to customise the response headers per `Controller` without the need to modify any PHP code.
+For deeper customisations, you also [set HTTP Cache headers directly](https://docs.silverstripe.org/en/4/developer_guides/performance/http_cache_headers/).
 
 #### Defaults
 
@@ -74,8 +82,10 @@ This means the response is classified as the "None" cache level.
 Cache-Control: no-cache, max-age=0, must-revalidate, no-transform
 ```
 
-Furthermore, all CWP instances are configured to set the following header on anything that is NOT served by the framework. This includes all requests for theme files and any asset requests that are not served by the [secureassets](https://github.com/silverstripe/silverstripe-secureassets) module.
-These responses are effectively the "Full" cache level. The `max-age` value is currently 120 seconds, but could change in the future. CWP customers can’t actively clear CDN caches on Incapsula unless they purchase an optional Premium Managed Service plan. Due to this restriction, asset invalidation needs to take place via the URL, through so called “cache busters”. SilverStripe adds a GET parameter with the last file modification timestamp to each stylesheet and javascript file included through its [Requirements API](http://docs.silverstripe.org/en/3/developer_guides/templates/requirements/). If you are referencing files in other ways, please take care to add your own “cache busters”, e.g. through a Grunt build task modifying the including SilverStripe template.
+Furthermore, all CWP instances are configured to set the following header on anything that is NOT served by the framework. This includes all requests for theme files and any asset requests that are not served by the [Secure Assets module](https://github.com/silverstripe/silverstripe-secureassets).
+These responses are effectively the "Full" cache level. The `max-age` value is currently 120 seconds, but could change in the future. CWP customers can’t actively clear CDN caches on Incapsula unless they purchase an [optional Premium Managed Service plan](https://www.cwp.govt.nz/features/optional-extras/). 
+Due to this restriction, asset invalidation needs to take place via the URL, through so called “cache busters”. SilverStripe adds a GET parameter with the last file modification timestamp to each stylesheet and javascript file included through its [Requirements API](http://docs.silverstripe.org/en/4/developer_guides/templates/requirements/). 
+If you are referencing files in other ways, please take care to add your own “cache busters”, e.g. through a Grunt build task modifying the including SilverStripe template.
 
 ```
 Cache-Control: max-age=120, public
@@ -83,7 +93,7 @@ Cache-Control: max-age=120, public
 
 #### Light caching on dynamic content
 
-You'll need to talk to your business owner about cache lifetimes: Updated content might not reach visitors until caches expire. This policy is generally safe, but specific controllers may need tweaks. For example the "userforms" module requires caching to be disabled through a `NoopPolicy` because it generates a unique form submission token for each visitor.
+You'll need to talk to your business owner about cache lifetimes: Updated content might not reach visitors until caches expire. This policy is generally safe, but specific controllers may need tweaks. For example, the [UserForms module](https://github.com/silverstripe/silverstripe-userforms) requires caching to be disabled through a `NoopPolicy` because it generates a unique form submission token for each visitor.
 
 ```
 Injector:
@@ -96,13 +106,15 @@ Page_Controller:
     Policies: '%$LightCachingPolicy'
 ```
 
-You might also want to inspect the default _Vary_ used by this module to see if it works well with your content, and perhaps adjust it via `CachingPolicy::vary` configuration option. See the "Varying content" chapter on the possible permutations of this header.
+You might also want to inspect the default _Vary_ used by this module to see if it works well with your content, and perhaps adjust it via `CachingPolicy::vary` configuration option. See the ["Varying content" chapter](#varying-content-2) on the possible permutations of this header.
 
 #### Full caching on dynamic content
 
-Full caching can only be achieved on dynamic content if that content is non-varying (see "Varying content" chapter).
+Full caching can only be achieved on dynamic content if that content is non-varying (see ["Varying content" chapter](#varying-content-2)).
 
-__Be cautious!__ If you feel uncertain about identifying content as non-varying, better stick to "Light" caching and avoid the danger of leaking user-specific or confidential data altogether.
+<div class="alert alert-warning" markdown='1'>
+Be cautious! If you feel uncertain about identifying content as non-varying, better stick to "Light" caching and avoid the danger of leaking user-specific or confidential data altogether.
+</div>
 
 ```
 Injector:
@@ -130,11 +142,11 @@ Login abilities, IP whitelisting, and Basic Authentication all imply the content
 
 Additionally, if you are serving both https and http from the same instance, you need to vary on _X-Forwarded-Protocol_ because of the `BaseURL` differences and the CWP network layout. You won't currently be able to use full caching on such double-protocol site.
 
-A table of some more obvious _Vary_ headers can be found in the [controllerpolicy documentation](https://github.com/silverstripe-labs/silverstripe-controllerpolicy/blob/master/README.md#vary-headers). Keep in mind the more of these you specify, the more cache variations you'll create. More variations make it less likely that your visitors will get a cached response.
+A table of some more obvious _Vary_ headers can be found in the [Controller Policy module documentation](https://github.com/silverstripe/silverstripe-controllerpolicy/blob/master/README.md#vary-headers). Keep in mind the more of these you specify, the more cache variations you'll create. More variations make it less likely that your visitors will get a cached response.
 
 Check your `.htaccess` files in the webroot and any subfolders, as they can influence the `Vary` header. For example, a `%{HTTP_HOST}` rewrite condition will [auto-add](http://httpd.apache.org/docs/current/mod/mod_rewrite.html) a `Vary: Host` header.
 
-If your content truly does not vary depending on the request, you will be able to utilise full caching for that URL - see the "Full caching on dynamic content" chapter.
+If your content truly does not vary depending on the request, you will be able to utilise full caching for that URL - see the ["Full caching on dynamic content" chapter](#full-caching-on-dynamic-content-2).
 
 Note that CWP's Local Cache (Varnish) has slightly different caching rules from the CDN (Incapsula). Depending on your headers, you might see cache hits from the Local Cache, but not from the CDN.
 
@@ -155,36 +167,39 @@ As an example the following will apply a new "cache for 900 seconds" header to a
 
 The [Incapsula](http://incapsula.com) CDN is active for all requests on all CWP sites by default. It respects HTTP cache
 headers both from static assets (usually configured through `.htaccess`), as well as dynamic SilverStripe responses
-configured through the controllerpolicy module.
+configured through the [Controller Policy module](https://github.com/silverstripe/silverstripe-controllerpolicy).
 
 If you opted for the Premium Managed Service you get readonly access to the Incapsula web-based dashboard incl. metrics. The CWP operations team remains responsible for changing configuration there. Please see the [site performance settings](https://incapsula.zendesk.com/hc/en-us/articles/200627760-Site-performance-settings) in the Incapsula docs for more information.
 
-If you haven't opted for the Premium Managed Service, requests to change Incapsula settings need to go through the CWP help desk.
+If you haven't opted for the [Premium Managed Service](https://www.cwp.govt.nz/features/optional-extras/), requests to change Incapsula settings need to go through the [CWP Service Desk](https://www.cwp.govt.nz/service-desk/new-request/).
 These changes only apply to your production environment. Other environments like Test or UAT share a common CWP configuration
 and can't be changed.
 
-By default the [Incapsula's performance settings](https://docs.incapsula.com/Content/management-console-and-settings/performance-settings.htm) are configured to be in __Static only__ mode, with "Comply with Vary: User-Agent" enabled. This safe default allows you to use all of the techniques described in the "Configuration via Headers" section above: _Static only_ makes sure the _Cache-Control_ header is respected and "Comply with Vary: User-Agent" makes Incapsula respect the "Vary" header.
-On CWP the _Static+Dynamic_ mode was not observed to be any different from the _Static only_ mode. The timeout settable on _Static+Dynamic_  will always be overriden by the "max-age" directive provided by the backend.
+By default the [Incapsula's performance settings](https://docs.incapsula.com/Content/management-console-and-settings/performance-settings.htm) are configured to be in __Static only__ mode, with "Comply with Vary: User-Agent" enabled. 
+This safe default allows you to use all of the techniques described in the "Configuration via Headers" section above: _Static only_ makes sure the _Cache-Control_ header is respected and "Comply with Vary: User-Agent" makes Incapsula respect the "Vary" header.
+On CWP the _Static+Dynamic_ mode was not observed to be any different from the _Static only_ mode. The timeout settable on _Static+Dynamic_  will always be overridden by the "max-age" directive provided by the backend.
 
 Incapsula will also attempt to compress JPEG and PNG images as well as minify CSS, but will not minify JS.
 
-
+<div class="alert alert-info" markdown='1'>
 Important: If you have a access to the Incapsula dashboard through the Premium Managed Service,
 your settings there only influence responses from your own domain(s).
 Content served through "*.cwp.govt.nz" domains will not be affected by your changes.
 This conveniently includes responses generated from the CMS admin area which shouldn't be retained in the cache at all.
+</div>
+
 
 ### Potentially dangerous settings in Incapsula
 
-We do not recommend switching the mode to __Aggressive__ nor disabling "Comply with Vary: User-Agent". These put you at a risk of leaking user-specific or confidential data and should only be considered for sites without varying content. The reasons are explained in the "Content Security" chapter.
+We neither recommend switching the mode to __Aggressive__ nor disabling "Comply with Vary: User-Agent". These put you at a risk of leaking user-specific or confidential data and should only be considered for sites without varying content. The reasons are explained in the "Content Security" chapter.
 
 You should not change these if any of the following is true:
 
-- You are actively using the [secureassets](https://github.com/silverstripe/silverstripe-secureassets) module
-- Sections of your publicly-accessible site are protected by HTTP Basic authentication
-- Your site is protected by an IP whitelist which wasn’t requested through CWP Service Desk
+- You are actively using the [Secure Assets module](https://github.com/silverstripe/silverstripe-secureassets).
+- Sections of your publicly-accessible site are protected by HTTP Basic authentication.
+- Your site is protected by an IP whitelist which wasn’t requested through the CWP Service Desk.
 
-See "Varying content" chapter for more details. If your site is completely public information, or you endeavour to maintain a tightly controlled list of Incapsula exceptions, you can change these __at your own risk__.
+See ["Varying content" chapter](#varying-content-2) for more details. If your site is completely public information, or you endeavour to maintain a tightly controlled list of Incapsula exceptions, you can change these __at your own risk__.
 
 ## Debugging
 
@@ -194,11 +209,11 @@ Request caching is complex and depends on many factors. The main method to debug
 
  * **Through CURL**: The `curl` commandline tool is widely available, and can be controlled more granularly than a browser. The following command sends a `GET` request, but only returns the HTTP headers. It also shows total time taken for the request. 
  `curl -s -D - -w 'Total (secs): %{time_total}' http://www.mydomain.govt.nz -o /dev/null`
- * **Through your browser**: Google Chrome has a developer toolbar with a "Network" panel. Always use an "Incognito" session to avoid using browser caches, and clear cookies before any request. Do not rely on the "disable cache" setting or hard reloads, since these methods will create inaccurate responses.
+ * **Through your browser**: Google Chrome has a developer toolbar with a "Network" panel. Always use an "Incognito" session to avoid using browser caches, and clear cookies before any request. Don't rely on the "disable cache" setting or hard reloads, since these methods will create inaccurate responses.
 
 ### Caching indicators
 
- * **Does the `Age` header count up?** It determines the cache age in seconds. For cached content, it should increase on subsequent requests. For uncached content, it either stays at zero or is not set at all. The [controllerpolicy](https://github.com/silverstripe-archive/silverstripe-controllerpolicy) module has more details on the various caching headers and how they influence caching behaviour.
+ * **Does the `Age` header count up?** It determines the cache age in seconds. For cached content, it should increase on subsequent requests. For uncached content, it either stays at zero or is not set at all. The [Controller Policy module](https://github.com/silverstripe-archive/silverstripe-controllerpolicy) has more details on the various caching headers and how they influence caching behaviour.
  * **Does the `X-Varnish` header contain two numbers?** Varnish [indicates](https://www.varnish-cache.org/docs/2.1/faq/http.html) cache hits through the presence of two numbers.
  * **Does the `X-Iinfo` header contain `C` values?** This Incapsula specific response header contains four characters which declare the caching level of the response (`NNNN` means not cached, `CNNN` or `NCNN` means cached). This behaviour is not officially documented by Incapsula, your mileage may vary.
  * **Incapsula cache stats** If you have opted to purchase the Premium Managed Service, the Incapsula dashboard will show you statistics on cache hit ratios. Otherwise you can contact the CWP Service Desk to retrieve this information for you.
@@ -209,35 +224,35 @@ The following are reasons why your response might not be cached:
 
  * **Vary header** Does your `Vary` header contain anything other than `Accept-Encoding`? See "Varying content" for more details.
  * **Cookies** Do you have any cookies set for this domain? Incapsula ignores it's own “utm” and “incap” cookies, any other cookies will likely prevent caching.
- * **PHP sessions** Any requests with a PHP session will prevent caching. Make sure that SilverStripe is not trying to start a PHP session alongside your request. SilverStripe will only attempt this if required by using the Session API in SilverStripe Framework. A PHP session will be started whenever a SilverStripe form is included in the generated HTML, in order to create a secure submission token. Please refer to SilverStripe’s [Secure Coding Guidelines](http://docs.silverstripe.org/en/3/developer_guides/security/secure_coding/#cross-site-request-forgery-csrf) to find out how and when to disable this submission token.
- * **Basic Authentication** Are you running HTTP Basic Authentication (e.g. on a UAT site)? This will prevent caching. You can disable authentication on a non-live site through YAML configuration (`BasicAuth.entire_site_protected`). Conditional HTTP basic authentication through IP whitelists might also interfere with caching. Please keep in mind that Incapsula won’t cache any responses which are sent with this authentication challenge. Since the same caching is applied to multiple requesting IPs, Incapsula might have already decided that the response is uncacheable based on previous requests.
+ * **PHP sessions** Any requests with a PHP session will prevent caching. Make sure that SilverStripe is not trying to start a PHP session alongside your request. SilverStripe will only attempt this if required by using the Session API in SilverStripe Framework. A PHP session will be started whenever a SilverStripe form is included in the generated HTML, in order to create a secure submission token. Please refer to SilverStripe’s [Secure Coding Guidelines](http://docs.silverstripe.org/en/4/developer_guides/security/secure_coding/#cross-site-request-forgery-csrf) to find out how and when to disable this submission token.
+ * **Basic Authentication** Are you running HTTP Basic Authentication (e.g. on a UAT site)? This will prevent caching. You can disable authentication on a non-live site through YAML configuration (`BasicAuth.entire_site_protected`). Conditional HTTP basic authentication through IP whitelists might also interfere with caching. Please keep in mind that Incapsula won’t cache any responses which are sent with this authentication challenge. Since the same caching is applied to multiple requesting IPs, Incapsula might have already decided that the response is non-cacheable based on previous requests.
  * **HTTP request verbs** Are you sending a GET request? Any other HTTP verb will prevent caching. This includes HEAD (commonly used through `curl -I`)
  * **HTTP response codes** Are you getting a HTTP 200 response code? Incapsula might not cache 3xx, 4xx or 5xx response codes  
  * **Cache preventing request headers:** Are you preventing caching through a “Cache-Control: private” or “Cache-Control: max-age=0” header? Are you sending `Pragma: no-cache`?
- * **Incapsula settings** Are you running any non-standard settings or have [path-specific cache rules](https://docs.incapsula.com/Content/management-console-and-settings/performance-settings.htm)? Contact CWP Service Desk or check your dashboard for Premium Managed Service
+ * **Incapsula settings** Are you running any non-standard settings or have [path-specific cache rules](https://docs.incapsula.com/Content/management-console-and-settings/performance-settings.htm)? Contact the CWP Service Desk or check your dashboard for Premium Managed Service.
  * **nginx settings** Has CWP operations set up any custom nginx rules for you?
  * **Different CDN nodes** By nature, a Content Delivery Network consists of globally distributed nodes. Subsequent requests might be processed by different nodes, even when coming from the same IP. Each of these nodes have their own caches. Retry your request a few times, the cache might still be propagating.
 
 ## FAQ
 
-**Q: Can I leverage caching so that I can fit my site on a "small" instance?**
+*Q: Can I leverage caching so that I can fit my site on a "small" instance?*
 
 To a certain degree, yes - if you are just worried about infrequent but large spikes of traffic. However since Incapsula has a bandwidth cap as well as CWP, you should not use this scheme to regularly go over the bandwidth and throughput limits allocated for your instance size. If your site consistently breaches these we will need to to upgrade your instance.
 
-**Q: What if I really don't want something cached in the transparent caches?**
+*Q: What if I really don't want something cached in the transparent caches?*
 
 It depends on the headers supplied by your site and your Incapsula options. If you absolutely don't want to use the cache make sure you supply a _Cache-Control_ header of "no-cache" and "max-age=0". You also need to avoid Incapsula "Aggressive" setting.
-If you are using [controllerpolicy](https://github.com/silverstripe-labs/silverstripe-controllerpolicy) you can apply a `NoopPolicy` to cancel any implicit policy on a specific controller - see the module's README instructon under "Overriding policies".
+If you are using [controllerpolicy](https://github.com/silverstripe-labs/silverstripe-controllerpolicy) you can apply a `NoopPolicy` to cancel any implicit policy on a specific controller - see the module's README instruction under "Overriding policies".
 
-**Q: How do I perform load testing on a CWP environment?**
+*Q: How do I perform load testing on a CWP environment?*
 
 There are various triggers in the CWP infrastructure which could detect unusually high load as denial of service attacks (DDos), and temporarily deny access to the originating IPs. In order to perform load testing, you need to contact the CWP Service Desk to whitelist IPs for this purpose. 
 
-**Q: Can I use HTTP-based caching with SSL?**
+*Q: Can I use HTTP-based caching with SSL?*
 
 Since SSL traffic is terminated before it hits CWP's Local Cache layer, you can also cache content delivered through HTTPS.
 
-*If you have any other questions, please contact the Service Desk.*
+*If you have any other questions, please contact the CWP Service Desk.*
 
 ## Resources
 

--- a/docs/en/04_Performance_Guide/03_Deferring_Work.md
+++ b/docs/en/04_Performance_Guide/03_Deferring_Work.md
@@ -1,6 +1,6 @@
 title: Deferring Work
-summary: How to avoid doing it all in the request
-introduction: Users shouldn't have to wait for a background process to finish before their page reloads
+summary: How to avoid doing it all in the request.
+introduction: Users shouldn't have to wait for a background process to finish before their page reloads.
 
 One of the most effective techniques for improving user experience and overall performance on a site is embracing the
 concept of deferring work; using a request to trigger a background process, rather than executing the process in the 
@@ -8,11 +8,11 @@ request itself.
  
 ## Queued Jobs
  
-Making use of the [Queued Jobs Module](https://github.com/silverstripe-australia/silverstripe-queuedjobs) is an easy
-way to get the best out of your site, and it comes bundled in to the CWP Basic Recipe. On request, you should create
+Making use of the [Queued Jobs Module](https://github.com/symbiote/silverstripe-queuedjobs) is an easy
+way to get the best out of your site, and it comes bundled in the [CWP Search Recipe](https://github.com/silverstripe/cwp-recipe-search). On request, you should create
 a job that performs the task in the background, to be processed when it reaches the front of the queue. In this way, 
 you give instant feedback to the user, and the task is able to be executed in the background - which has less overhead 
-than the web version of the same request. Additionally, you should batch any requests that deal with large datasets, or 
+than the web version of the same request. Additionally, you should batch any requests that deal with large data sets, or 
 tasks that take a long time to process.
 
 For example, if you have a sign-up form that requires a large amount of processing before sending out a confirmation 
@@ -22,7 +22,7 @@ confirmation to the user once the job has been added, and let the queue run the 
 may mean a small delay on the sending of the email while the job makes its way to the top of the queue, but it provides 
 a much better experience for the user - and reduces the impact on the server.
 
-<div class="notice">
+<div class="alert alert-info">
     This also helps to mitigate the impact of Denial of Service (DOS) attacks, as it is much harder to induce load when 
     you remove the processing from the request. The queue ensures sensible distribution of the server resources.
 </div>
@@ -40,8 +40,8 @@ executed at a time that will impact the least number of users. There are
 [a lot of ways to tweak the frequency](http://www.thegeekstuff.com/2009/06/15-practical-crontab-examples) to achieve 
 what you need. This is especially useful if you need to export or import a large amount of data on a schedule.
 
-On CWP these will need to be added via a Service Desk request; alternatively you can utilise the 
-[Crontask module](https://github.com/silverstripe/silverstripe-crontask) to retain complete developer control over the 
+On CWP these will need to be added via a [CWP Service Desk request](https://www.cwp.govt.nz/service-desk/new-request/); alternatively you can utilise the 
+[CronTask module](https://github.com/silverstripe/silverstripe-crontask) to retain complete developer control over the 
 jobs. This will then require that a cron job be set up to run the cron tasks, but that means it is a one-off rather than
 per-task request.
 

--- a/docs/en/04_Performance_Guide/04_Frontend_Best_Practices.md
+++ b/docs/en/04_Performance_Guide/04_Frontend_Best_Practices.md
@@ -36,7 +36,7 @@ this is not as good for HTTP requests, as the browser will limit the number of s
 parallel. Combining them means less requests, and a faster load time.
 
 SilverStripe comes with a built-in method of combining your CSS and JavaScript files. Have a look at
-[the documentation](https://docs.silverstripe.org/en/3/developer_guides/templates/requirements/#combining-files) to see 
+[the documentation](https://docs.silverstripe.org/en/4/developer_guides/templates/requirements/#combining-files) to see 
 how easy it is - and remember, if your site is in `dev` mode, combined files will be disabled!
 
 [read more...](https://browserdiet.com/#combine-css)
@@ -47,6 +47,9 @@ To understand the value of asynchronous loading, we need to understand how the H
 bottom. With a standard load, you need to wait for any given element to load before the ones below it do. However, if we
 load something large (say, a script) asynchronously, we can let the HTML around it load, and then execute once the
 entire script has loaded. This is particularly advantageous in two situations:
+
+* [Large Scripts](#large-scripts-2)
+* [Third-party Content](#third-party-content-2)
 
 ### Large Scripts
 
@@ -72,7 +75,7 @@ bring this content in asynchronously.
 
 [read more...](https://browserdiet.com/#3rd-party-async)
 
-For more information on optimising your third-party integrations, see [our guide](../third-party-link).
+For more information on optimising your third-party integrations, see [our guide](../third-parties).
 
 ## Next
 

--- a/docs/en/04_Performance_Guide/05_Third_Parties.md
+++ b/docs/en/04_Performance_Guide/05_Third_Parties.md
@@ -21,7 +21,7 @@ worth speaking with the external provider to find out what their expectation is 
 A good rule of thumb is to expect most requests to respond within 5 seconds; but remember, if you set a timeout to 5 
 seconds, then on some page loads you may see loading times increase by this much to accommodate slow responses. 
 
-<div class="notice">
+<div class="alert alert-info">
 Note that if a response from your site to your visitor takes over 30 seconds, a 502 error response will be sent by the
 CWP infrastructure, regardless of other timeout settings.
 </div>
@@ -51,7 +51,7 @@ Many times the data you'll be fetching from external providers will change infre
 longer without going "stale" (where the data you've cached is out-of-date compared to the live data source). Often there
 will be little harm in showing stale data to your visitors.
 
-<div class="notice">
+<div class="alert alert-info">
 Discuss with your stakeholders what level of stale data is acceptable - it may be different for each piece of data 
 you cache.
 </div>
@@ -78,7 +78,7 @@ When integrating APIs, we need to bear in mind that they will suffer from the sa
 availability and handling load. This requires that we take into account the availability of the APIs and what level of 
 impact is acceptable for our site.
 
-For some sites an API will be as integral to the site as the database; without it the site cannot work. When this is 
+For some sites an API will be as integral to the site as the database; without it the site can't work. When this is 
 the case, you still want to handle API failures gracefully - perhaps by retrying - if the API continues to fail 
 you'll want to log the issue internally and respond with an HTTP 502 error.
 

--- a/docs/en/04_Performance_Guide/06_404s.md
+++ b/docs/en/04_Performance_Guide/06_404s.md
@@ -1,5 +1,5 @@
 title: Dealing with 404s
-summary: For when things are missing
+summary: For when things are missing.
 introduction: One of the most expensive requests on a SilverStripe site is the 404. Here are some common ways to avoid overloading your site with requests for things that aren't there.
 
 ## Common 404s
@@ -10,15 +10,15 @@ that can be easily prevented:
 
 ### Legacy URLs
 
-If you are migrating or rebuilding site, there can be URLs from the original site that will no longer resolve once 
+If you are migrating or rebuilding a site, there can be URLs from the original site that will no longer resolve once 
 the site has been moved to CWP. For example, if the site `www.ministryofmagic.govt.nz` is migrated to CWP, and the 
 news section has been renamed from `/news` to `/daily-prophet`, you may still have links, external or otherwise, 
 that are pointing to the old URL. This problem can be especially severe just after launching the new site as search 
-engine spiders will check all of the old URLs they have to see if they've changed.
+engine crawlers will check all of the old URLs they have to see if they've changed.
 
 It's important to deal with legacy URLs, not only because it reduces needless server load, but because it will 
 provide a better experience for your users. Links from bookmarks or other sites should still work even after 
-you've updated you site. Forwarding legacy URLs will also help you maintain your search engine rankings that have 
+you've updated your site. Forwarding legacy URLs will also help you maintain your search engine rankings that have 
 been earned.
 
 The best solution to this is to configure a permanent redirect in your `.htaccess` file - see 
@@ -29,8 +29,8 @@ or redirect to the homepage.
 
 Your `.htaccess` file should live in the webroot - if you've used the 
 [CWP Installer](https://www.cwp.govt.nz/developer-docs/en/getting_started/)
-you should have one in your webroot already - you can just append new configuration to the bottom. Alternatively, the
-[silverstripe/redirectedurls module](http://addons.silverstripe.org/add-ons/silverstripe/redirectedurls) can provide
+you should have one in your webroot already - you can just append the new configuration to the bottom. Alternatively, the
+[Redirected URLs module](https://github.com/silverstripe/silverstripe-redirectedurls) can provide
 similar redirect functionality from within the CMS.
 
 Common culprits include `favicon.ico` and `/autodiscover/autodiscover.xml` - if you know where the request should go, 
@@ -48,7 +48,7 @@ pointing to a missing resource.
 
 [Google Webmaster Tools](https://www.google.com/webmasters) is a useful resource for identifying 404s in your live 
 site. Otherwise, you can use the server logs. If you don't already have access to Graylog, you can request access
-through the [CWP Helpdesk](https://www.cwp.govt.nz/service-desk/new-request/). Once there, you can use the dropdown 
+through the [CWP Service Desk](https://www.cwp.govt.nz/service-desk/new-request/). Once there, you can use the dropdown 
 to filter through your stream for 404 responses.
 
 ![Filter for 404s](../_images/graylogfilters.PNG)

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.0.4.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.0.4.md
@@ -5,17 +5,17 @@
 This release tracks the Framework release 3.1.6 and fixes some module bugs. The highlights are:
 
 * Addition of five new modules:
-  * [external links checker](https://github.com/silverstripe/silverstripe-externallinks)
+  * [external links checker](https://github.com/silverstripe-labs/silverstripe-externallinks)
     to detect broken links to external sites within pages.
-  * [mime validator](https://github.com/silverstripe/silverstripe-mimevalidator)
+  * [mime validator](https://github.com/silverstripe-labs/silverstripe-mimevalidator)
     module which validates the content of uploaded files.
-  * [select upload](https://github.com/silverstripe/silverstripe-selectupload)
+  * [select upload](https://github.com/silverstripe-labs/silverstripe-selectupload)
     to select where you want to upload files.
-  * [spell check](https://github.com/silverstripe/silverstripe-spellcheck)
+  * [spell check](https://github.com/silverstripe-labs/silverstripe-spellcheck)
     to provide spell checking support in NZ English and Maori locales.
-  * [hybrid sessions](https://github.com/silverstripe/silverstripe-hybridsessions)
+  * [hybrid sessions](https://github.com/silverstripe-labs/silverstripe-hybridsessions)
 * Several fixes to usability issues with
-   [advanced workflow module](https://github.com/symbiote/advancedworkflow).
+   [advanced workflow module](https://github.com/silverstripe-australia/advancedworkflow).
 * Additional support for [active disaster recovery](https://www.cwp.govt.nz/about/selecting-the-attributes-of-the-common-web-platform-instance-for-your-websites/#disaster-recovery-options)
    server configurations. When servers are arranged with multiple physical nodes in different geographic locations,
    user traffic may not always be served by the same one. Additional functionality is provided by the hybrid

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.0.4.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.0.4.md
@@ -5,17 +5,17 @@
 This release tracks the Framework release 3.1.6 and fixes some module bugs. The highlights are:
 
 * Addition of five new modules:
-  * [external links checker](https://github.com/silverstripe-labs/silverstripe-externallinks)
+  * [external links checker](https://github.com/silverstripe/silverstripe-externallinks)
     to detect broken links to external sites within pages.
-  * [mime validator](https://github.com/silverstripe-labs/silverstripe-mimevalidator)
+  * [mime validator](https://github.com/silverstripe/silverstripe-mimevalidator)
     module which validates the content of uploaded files.
-  * [select upload](https://github.com/silverstripe-labs/silverstripe-selectupload)
+  * [select upload](https://github.com/silverstripe/silverstripe-selectupload)
     to select where you want to upload files.
-  * [spell check](https://github.com/silverstripe-labs/silverstripe-spellcheck)
+  * [spell check](https://github.com/silverstripe/silverstripe-spellcheck)
     to provide spell checking support in NZ English and Maori locales.
-  * [hybrid sessions](https://github.com/silverstripe-labs/silverstripe-hybridsessions)
+  * [hybrid sessions](https://github.com/silverstripe/silverstripe-hybridsessions)
 * Several fixes to usability issues with
-   [advanced workflow module](https://github.com/silverstripe-australia/advancedworkflow).
+   [advanced workflow module](https://github.com/symbiote/advancedworkflow).
 * Additional support for [active disaster recovery](https://www.cwp.govt.nz/about/selecting-the-attributes-of-the-common-web-platform-instance-for-your-websites/#disaster-recovery-options)
    server configurations. When servers are arranged with multiple physical nodes in different geographic locations,
    user traffic may not always be served by the same one. Additional functionality is provided by the hybrid

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.1.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.1.0.md
@@ -14,7 +14,7 @@ The following new major features are included in this release:
 
  * Full blogging support, including nested comments, moderation tools, and multi-user functionality. Details on the new blog recipe can be found on the [blog recipe](/cwp-features/blog_recipe) page.
  * The ability to index and search uploaded documents via fulltext search. This is currently a beta feature, and any agency using this is advised to complete feasibility testing on any target environment. Details on configuring your environments for searching documents can be found on the [solr search](/cwp-features/solr_search) page.
- * A Single Sign-On functionality for SilverStripe intranet sites has been created. It is optional functionality and will require specific infrastructural architecture. See the [single sign on documentation](/cwp-features/single_sign_on).
+ * A single sign-on functionality for SilverStripe intranet sites has been created. It is optional functionality and will require specific infrastructural architecture. See the [single sign on documentation](/cwp-features/single_sign_on).
 
 Also included is a new file-tracking system to display which pages each image appears on.
 
@@ -30,7 +30,7 @@ Information to help manage upgrades is [here](https://www.cwp.govt.nz/working-wi
 ## Upgrading Instructions
 
 In order to assist agencies to upgrade their existing sites without the inclusion of new 1.1.0 blog features,
-these have been separated into a new module, [cwp-recipe-blog](https://gitlab.cwp.govt.nz/cwp/cwp-recipe-blog),
+these have been separated into a new module, [cwp-recipe-blog](https://github.com/silverstripe/cwp-recipe-blog),
 which can be optionally excluded from any upgrade if desired.
 
 Document searching and Active Directory are supported but not installed by default, and thus can be excluded from

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.1.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.1.0.md
@@ -14,7 +14,7 @@ The following new major features are included in this release:
 
  * Full blogging support, including nested comments, moderation tools, and multi-user functionality. Details on the new blog recipe can be found on the [blog recipe](/cwp-features/blog_recipe) page.
  * The ability to index and search uploaded documents via fulltext search. This is currently a beta feature, and any agency using this is advised to complete feasibility testing on any target environment. Details on configuring your environments for searching documents can be found on the [solr search](/cwp-features/solr_search) page.
- * A single sign-on functionality for SilverStripe intranet sites has been created. It is optional functionality and will require specific infrastructural architecture. See the [single sign on documentation](/cwp-features/single_sign_on).
+ * A Single Sign-On functionality for SilverStripe intranet sites has been created. It is optional functionality and will require specific infrastructural architecture. See the [single sign on documentation](/cwp-features/single_sign_on).
 
 Also included is a new file-tracking system to display which pages each image appears on.
 
@@ -30,7 +30,7 @@ Information to help manage upgrades is [here](https://www.cwp.govt.nz/working-wi
 ## Upgrading Instructions
 
 In order to assist agencies to upgrade their existing sites without the inclusion of new 1.1.0 blog features,
-these have been separated into a new module, [cwp-recipe-blog](https://github.com/silverstripe/cwp-recipe-blog),
+these have been separated into a new module, [cwp-recipe-blog](https://gitlab.cwp.govt.nz/cwp/cwp-recipe-blog),
 which can be optionally excluded from any upgrade if desired.
 
 Document searching and Active Directory are supported but not installed by default, and thus can be excluded from

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.3.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.3.0.md
@@ -111,11 +111,11 @@ In recipe 1.3.0 there are the following known issues in these failing tests:
 #### framework
 
  * FolderTest.testRenameFolderAndCheckTheFile - Known compatibility issue in versionedfiles
-   with 3.2. See https://github.com/silverstripe-australia/silverstripe-versionedfiles/issues/43
+   with 3.2. See https://github.com/symbiote/silverstripe-versionedfiles/issues/43
  * FolderTest.testSetNameChangesFilesystemOnWrite - Known compatibility issue in versionedfiles
-   with 3.2. See https://github.com/silverstripe-australia/silverstripe-versionedfiles/issues/43
+   with 3.2. See https://github.com/symbiote/silverstripe-versionedfiles/issues/43
  * FolderTest.testSetParentIDChangesFilesystemOnWrite - Known compatibility issue in versionedfiles
-   with 3.2. See https://github.com/silverstripe-australia/silverstripe-versionedfiles/issues/43
+   with 3.2. See https://github.com/symbiote/silverstripe-versionedfiles/issues/43
    
 #### userforms
 

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.3.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.3.0.md
@@ -111,11 +111,11 @@ In recipe 1.3.0 there are the following known issues in these failing tests:
 #### framework
 
  * FolderTest.testRenameFolderAndCheckTheFile - Known compatibility issue in versionedfiles
-   with 3.2. See https://github.com/symbiote/silverstripe-versionedfiles/issues/43
+   with 3.2. See https://github.com/silverstripe-australia/silverstripe-versionedfiles/issues/43
  * FolderTest.testSetNameChangesFilesystemOnWrite - Known compatibility issue in versionedfiles
-   with 3.2. See https://github.com/symbiote/silverstripe-versionedfiles/issues/43
+   with 3.2. See https://github.com/silverstripe-australia/silverstripe-versionedfiles/issues/43
  * FolderTest.testSetParentIDChangesFilesystemOnWrite - Known compatibility issue in versionedfiles
-   with 3.2. See https://github.com/symbiote/silverstripe-versionedfiles/issues/43
+   with 3.2. See https://github.com/silverstripe-australia/silverstripe-versionedfiles/issues/43
    
 #### userforms
 

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.6.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.6.0.md
@@ -59,7 +59,7 @@ CwpThemeHelper:
 ```php
 <?php
 
-Config::inst()->update('CwpThemeHelper', 'default_themes', array('my_custom_theme_name'));
+Config::inst()->update('CwpThemeHelper', 'default_themes', ['my_custom_theme_name']);
 ```
 
 #### SSViewer Theme
@@ -80,8 +80,8 @@ In previous versions of the recipe, you may have followed the **"Adding JS and C
 Let's start with creating our Extension. You could name it `BasePageControllerExtension` for example. It should look something like this: 
 
 ```php
-class BasePageControllerExtension extends Extension 
-{ 
+class BasePageControllerExtension extends Extension
+{
    ... 
 }
 ```
@@ -99,7 +99,7 @@ You're now all set up for Steps 2 and 3. Let's get to it!
 
 ##### Step 2: From `getBaseScripts` to `updateBaseScripts`
 
-If you have overriden `getBaseScripts`, you will need to add the `updateBaseScripts` method to your `BasePageControllerExtension`. There are **two** ways this is likely to go for you depending on how you have overridden `getBaseScripts` and if you have (or have not) made use of the `parent::getBaseScripts()` method: 
+If you have overridden `getBaseScripts`, you will need to add the `updateBaseScripts` method to your `BasePageControllerExtension`. There are **two** ways this is likely to go for you depending on how you have overridden `getBaseScripts` and if you have (or have not) made use of the `parent::getBaseScripts()` method: 
 
 ###### 1. `Page_Controller` has the method `getBaseScripts` and it makes use of `parent::getBaseScripts()` like this: 
 
@@ -122,9 +122,9 @@ public function updateBaseScripts(&$scripts)
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    $scripts = array_merge($scripts, array(
+    $scripts = array_merge($scripts, [
         "$themeDir/js/my.js"
-    ));
+    ]);
 }
 ```
 
@@ -135,9 +135,9 @@ public function getBaseScripts()
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    return array(
+    return [
     	"$themeDir/js/my.js"
-    );
+    ];
 }
 ```
 
@@ -148,9 +148,9 @@ public function updateBaseScripts(&$scripts)
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    $scripts = array_merge($scripts, array(
+    $scripts = array_merge($scripts, [
         "$themeDir/js/my.js"
-    ));
+    ]);
 }
 ```
 
@@ -163,7 +163,7 @@ DefaultThemeExtension:
 
 ##### Step 3: From `getBaseStyles` to `updateBaseStyles`
 
-If you have overriden `getBaseStyles`, you will need to add the `updateBaseStyles` method to your `BasePageControllerExtension`. There are **two** ways this is likely to go for you depending on how you have overridden `getBaseStyles` and if you have (or have not) made use of the `parent::getBaseStyles()` method: 
+If you have overridden `getBaseStyles`, you will need to add the `updateBaseStyles` method to your `BasePageControllerExtension`. There are **two** ways this is likely to go for you depending on how you have overridden `getBaseStyles` and if you have (or have not) made use of the `parent::getBaseStyles()` method: 
 
 ###### 1. `Page_Controller` has the method `getBaseStyles` and it makes use of `parent:: getBaseStyles()` like this: 
 
@@ -186,9 +186,9 @@ public function updateBaseStyles(&$styles)
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    $styles['all'] = array_merge($styles['all'], array(
+    $styles['all'] = array_merge($styles['all'], [
         "$themeDir/css/my.css"
-    ));
+    ]);
 }
 ```
 
@@ -199,9 +199,9 @@ public function getBaseStyles()
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    return array(
+    return [
     	"all" => "$themeDir/css/my.css"
-    );
+    ];
 }
 ```
 
@@ -212,9 +212,9 @@ public function updateBaseStyles(&$styles)
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    $styles['all'] = array_merge($styles['all'], array(
+    $styles['all'] = array_merge($styles['all'], [
         "$themeDir/css/my.css"
-    ));
+    ]);
 }
 ```
 

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.6.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.6.0.md
@@ -59,7 +59,7 @@ CwpThemeHelper:
 ```php
 <?php
 
-Config::inst()->update('CwpThemeHelper', 'default_themes', ['my_custom_theme_name']);
+Config::inst()->update('CwpThemeHelper', 'default_themes', array('my_custom_theme_name'));
 ```
 
 #### SSViewer Theme
@@ -80,8 +80,8 @@ In previous versions of the recipe, you may have followed the **"Adding JS and C
 Let's start with creating our Extension. You could name it `BasePageControllerExtension` for example. It should look something like this: 
 
 ```php
-class BasePageControllerExtension extends Extension
-{
+class BasePageControllerExtension extends Extension 
+{ 
    ... 
 }
 ```
@@ -99,7 +99,7 @@ You're now all set up for Steps 2 and 3. Let's get to it!
 
 ##### Step 2: From `getBaseScripts` to `updateBaseScripts`
 
-If you have overridden `getBaseScripts`, you will need to add the `updateBaseScripts` method to your `BasePageControllerExtension`. There are **two** ways this is likely to go for you depending on how you have overridden `getBaseScripts` and if you have (or have not) made use of the `parent::getBaseScripts()` method: 
+If you have overriden `getBaseScripts`, you will need to add the `updateBaseScripts` method to your `BasePageControllerExtension`. There are **two** ways this is likely to go for you depending on how you have overridden `getBaseScripts` and if you have (or have not) made use of the `parent::getBaseScripts()` method: 
 
 ###### 1. `Page_Controller` has the method `getBaseScripts` and it makes use of `parent::getBaseScripts()` like this: 
 
@@ -122,9 +122,9 @@ public function updateBaseScripts(&$scripts)
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    $scripts = array_merge($scripts, [
+    $scripts = array_merge($scripts, array(
         "$themeDir/js/my.js"
-    ]);
+    ));
 }
 ```
 
@@ -135,9 +135,9 @@ public function getBaseScripts()
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    return [
+    return array(
     	"$themeDir/js/my.js"
-    ];
+    );
 }
 ```
 
@@ -148,9 +148,9 @@ public function updateBaseScripts(&$scripts)
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    $scripts = array_merge($scripts, [
+    $scripts = array_merge($scripts, array(
         "$themeDir/js/my.js"
-    ]);
+    ));
 }
 ```
 
@@ -163,7 +163,7 @@ DefaultThemeExtension:
 
 ##### Step 3: From `getBaseStyles` to `updateBaseStyles`
 
-If you have overridden `getBaseStyles`, you will need to add the `updateBaseStyles` method to your `BasePageControllerExtension`. There are **two** ways this is likely to go for you depending on how you have overridden `getBaseStyles` and if you have (or have not) made use of the `parent::getBaseStyles()` method: 
+If you have overriden `getBaseStyles`, you will need to add the `updateBaseStyles` method to your `BasePageControllerExtension`. There are **two** ways this is likely to go for you depending on how you have overridden `getBaseStyles` and if you have (or have not) made use of the `parent::getBaseStyles()` method: 
 
 ###### 1. `Page_Controller` has the method `getBaseStyles` and it makes use of `parent:: getBaseStyles()` like this: 
 
@@ -186,9 +186,9 @@ public function updateBaseStyles(&$styles)
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    $styles['all'] = array_merge($styles['all'], [
+    $styles['all'] = array_merge($styles['all'], array(
         "$themeDir/css/my.css"
-    ]);
+    ));
 }
 ```
 
@@ -199,9 +199,9 @@ public function getBaseStyles()
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    return [
+    return array(
     	"all" => "$themeDir/css/my.css"
-    ];
+    );
 }
 ```
 
@@ -212,9 +212,9 @@ public function updateBaseStyles(&$styles)
 {
     $themeDir = SSViewer::get_theme_folder();
 
-    $styles['all'] = array_merge($styles['all'], [
+    $styles['all'] = array_merge($styles['all'], array(
         "$themeDir/css/my.css"
-    ]);
+    ));
 }
 ```
 

--- a/docs/en/05_Releases_and_changelogs/index.md
+++ b/docs/en/05_Releases_and_changelogs/index.md
@@ -29,6 +29,4 @@ introduction: The status of the recipe releases is summarised in the table below
 | [1.0.2](cwp_recipe_basic_1.0.2) | Tracks the Framework release 3.1.2 and fixes some module bugs. | 30/01/2014 | 31/05/2015 |
 | [1.0.1](cwp_recipe_basic_1.0.1) | First release of the recipe and all related modules. | 12/11/2013 | 31/05/2015 |
 
-# Other supported module releases
-
-Currently all supported modules are a part of the basic recipe.
+Currently all modules in the CWP recipes are commercially supported by SilverStripe Ltd.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -6,7 +6,7 @@ introduction: This documentation covers specific information regarding how to wo
 This codebase is referred to as the CWP `Recipe` and is made up of your own custom developed code alongside:
  
  * SilverStripe CMS (open source CMS product).
- * SilverStripe commercially supported modules (which deliverers many of the default features). 
+ * SilverStripe commercially supported modules (which deliver many of the default features). 
  * Two CWP specific modules (cwp and cwp-core) that implement specific configuration and features related to running websites on CWP.
 
 For general information about working with SilverStripe CMS code, please consult the


### PR DESCRIPTION
Addresses one of the subtasks in #42 

It updates the links to GitHub and GitLab repos, fixes typos and some wording as well as converts the sample code to align with PSR-2. 

Most importantly, it adds the new CWP 2.0 recipes and their contents as well as the possible combinations. 