### PR TITLE
FIX Correct the end of support date for 1.8.0 release

### DIFF
--- a/docs/en/05_Releases_and_changelogs/index.md
+++ b/docs/en/05_Releases_and_changelogs/index.md
@@ -7,7 +7,7 @@ introduction: The status of the recipe releases is summarised in the table below
 | Recipe version | Description | Release date | Support ends date |
 | -------------- | ----------- | ------------ | ----------------- |
 | [1.8.1](cwp_recipe_basic_1.8.1) | Tracks the Framework release 3.6.5, and includes minor module bug fixes. | 12/03/2018 | current |
-| [1.8.0](cwp_recipe_basic_1.8.0) | Tracks the Framework release 3.6.3 and includes security fixes. | 11/12/2017 | 12/03/2018 |
+| [1.8.0](cwp_recipe_basic_1.8.0) | Tracks the Framework release 3.6.3 and includes security fixes. | 11/12/2017 | 12/09/2019 |
 | [1.7.0](cwp_recipe_basic_1.7.0) | Tracks the Framework release 3.6.1 and includes security fixes. | 28/09/2017 | 11/06/2019 |
 | [1.6.0](cwp_recipe_basic_1.6.0) | Tracks the Framework release 3.6.0 and includes security fixes. | 02/06/2017 | 28/03/2019 |
 | [1.5.2](cwp_recipe_basic_1.5.2) | Tracks the Framework release 3.5.3 and includes a security fix. | 27/02/2017 | 02/12/2018 |


### PR DESCRIPTION
Accidentally during the last release (or merge up) the date for
end of support for 1.8.0 became the release date for 1.8.1 instead
of 18 months from that date. Corrected in this commit.