### PR TITLE
Only add File_ShowInSearch when File class in query

### DIFF
--- a/code/search/CwpSearchEngine.php
+++ b/code/search/CwpSearchEngine.php
@@ -42,7 +42,12 @@ class CwpSearchEngine extends Object {
 		$query->classes = $classes;
 		$query->search($keywords);
 		$query->exclude('SiteTree_ShowInSearch', 0);
-        $query->exclude('File_ShowInSearch', 0);
+
+		// Add File_ShowInSearch if the File class is in the query
+        $classes = array_column($classes, 'class');
+        if (in_array('File', $classes)) {
+            $query->exclude('File_ShowInSearch', 0);
+        }
 
 		// Artificially lower the amount of results to prevent too high resource usage.
 		// on subsequent canView check loop.


### PR DESCRIPTION
Adds conditional around changes introduced in 22111c2b0c656251e1f15173913c789402e085e3 to prevent a `search field empty` error within fulltext search (see silverstripe/silverstripe-fulltextsearch/issues/211).

Thanks @robbieaverill for your help with this