### PR TITLE
FIX Unentice direct BasePage creation in the CMS

### DIFF
--- a/src/Extensions/TaxonomyTermExtension.php
+++ b/src/Extensions/TaxonomyTermExtension.php
@@ -4,6 +4,8 @@ namespace CWP\CWP\Extensions;
 
 use CWP\CWP\PageTypes\BasePage;
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 
 class TaxonomyTermExtension extends DataExtension
 {
@@ -13,4 +15,12 @@ class TaxonomyTermExtension extends DataExtension
     private static $belongs_many_many = array(
         'Pages' => BasePage::class
     );
+
+    public function updateCMSFields(FieldList $fields)
+    {
+        $pagesGridField = $fields->dataFieldByName('Pages');
+        if ($pagesGridField) {
+            $pagesGridField->getConfig()->removeComponentsByType(GridFieldAddNewButton::class);
+        }
+    }
 }


### PR DESCRIPTION
The extension for TaxonomyTerm applies a relation to Page,
which is BasePage. The nature of BasePage is that is _should_ be
`abstract`, and should not be created. Unfortunately for us the
default scaffolder offers a CMS user the option to create a base page
via the relation to TaxonomyTerm. This commit stops that.

Resolves https://github.com/silverstripe/silverstripe-taxonomy/issues/53