### PR TITLE
fix regex issue in performance docs

### DIFF
--- a/docs/en/03_How_tos/caching.md
+++ b/docs/en/03_How_tos/caching.md
@@ -145,7 +145,7 @@ As an example the following will apply a new "cache for 900 seconds" header to a
 
 ```
   <IfModule mod_headers.c>
-    SetEnvIf Request_URI ".*.php$" NO_CACHE=true
+    SetEnvIf Request_URI ".*\.php$" NO_CACHE=true
     Header set Cache-Control "max-age=900, public" env=!NO_CACHE
   </IfModule>
 ```


### PR DESCRIPTION
Hi Team,
This regex in the docs matches for .* 0-many characters then any character then php.
I think the intention was anything ending in .php
this pull request fixes 1.5 branch and I've got another for 1.7 onwards because the content moved.