### PR TITLE
fix regex in performance guide htaccess rules

### DIFF
--- a/docs/en/04_Performance_Guide/02_HTTP_Caching.md
+++ b/docs/en/04_Performance_Guide/02_HTTP_Caching.md
@@ -146,7 +146,7 @@ As an example the following will apply a new "cache for 900 seconds" header to a
 
 ```
   <IfModule mod_headers.c>
-    SetEnvIf Request_URI ".*.php$" NO_CACHE=true
+    SetEnvIf Request_URI ".*\.php$" NO_CACHE=true
     Header set Cache-Control "max-age=900, public" env=!NO_CACHE
   </IfModule>
 ``` 


### PR DESCRIPTION
Hi Team,
This regex in the docs matches for .* 0-many characters then any character then php.
I think the intention was to match anything ending in .php
this pull request fixes 1.7 onwards because the content moved from 1.5.