### PR TITLE
Update broken links

### DIFF
--- a/docs/en/00_Getting_started.md
+++ b/docs/en/00_Getting_started.md
@@ -10,21 +10,19 @@ code to GitLab.
 ## Before you begin
 This guide assumes you already have:
 
-* A server with [Apache, MySQL and PHP](working_with_projects/setting_up_a_development_environment)
-* [Git version control](working_with_projects/setting_up_a_development_environment/#git)
+* A server with [Apache, MySQL and PHP](01_Working_with_projects/00_Setting_up_a_development_environment.md)
+* [Git version control](01_Working_with_projects/00_Setting_up_a_development_environment.md/#git)
 * [Composer](https://docs.silverstripe.org/en/4/getting_started/composer/)
 
 If you're using Windows, you can use a command-line equivalent to interact with git and composer, offered by the [MsysGit package](http://msysgit.github.io)
 
 ### Have an existing GitLab project?
 
-Follow the instructions at [Setting up your project](working_with_projects/setting_up_your_project) to setup an environment with an existing CWP project.
+Follow the instructions at [Setting up your project](01_Working_with_projects/01_Setting_up_your_project.md) to setup an environment with an existing CWP project.
 
 ## Getting started with CWP codebase from scratch:
 
-<div class="alert alert-info" markdown='1'>
 Please replace "my-project" below with the actual name of your project. One naming technique is to use the intended project's hostname e.g. "my-project.govt.nz" as the project's folder name
-</div>
 
 1. Change into your web server's document root: `cd /var/www/htdocs`
 2. Create new project using Composer by running the following command:
@@ -37,7 +35,7 @@ This may take some time to run as it is collecting and downloading all the code 
 5. Make sure your folder permissions are correctly set (see [File permission problems](https://docs.silverstripe.org/en/4/getting_started/installation/common_problems/#i-ve-got-file-permission-problems-during-installation)), you will also need to create an 'assets' folder if one isn't already created
 6. Create a `.env` environment file in the `/htdocs` folder and fill it in with your local details
 
- * [CWP Environment variables](working_with_projects/cwp_environment_variables/) has more details about CWP specific variables that you can set in your environment file
+ * [CWP Environment variables](01_Working_with_projects/12_CWP_environment_variables.md) has more details about CWP specific variables that you can set in your environment file
  * [Environment management](https://docs.silverstripe.org/en/4/getting_started/environment_management/) has more details about how to create a environment file
  * Adding `SS_SEND_ALL_EMAILS_TO='your@address.govt.nz'` stops any debugging emails going out accidentally to live emails
 
@@ -45,9 +43,9 @@ This may take some time to run as it is collecting and downloading all the code 
 
 You should now be able to visit: http://localhost/my-project and see a basic CWP-themed site in your browser.
 
-For a more in-depth walkthrough through CWP development activities, please refer to ["Working with projects"](working_with_projects).
+For a more in-depth walkthrough through CWP development activities, please refer to ["Working with projects"](01_Working_with_projects).
 Even if you already know how to develop in SilverStripe, please review our
-[Performance Guide](performance-guide) to ensure you create a stable and performant site.
+[Performance Guide](04_Performance_Guide) to ensure you create a stable and performant site.
 
 ## Troubleshooting
 

--- a/docs/en/01_Working_with_projects/00_Setting_up_a_development_environment.md
+++ b/docs/en/01_Working_with_projects/00_Setting_up_a_development_environment.md
@@ -11,19 +11,17 @@ CWP projects are installed using the Composer PHP package management tool. For g
 the [SilverStripe Composer documentation](https://docs.silverstripe.org/en/3/getting_started/composer/) or read the
 installation documentation on the [Composer site](http://getcomposer.org/doc/00-intro.md).
 
-Please familiarise yourself with the [CWP recipes](recipes_and_supported_modules) before starting to develop on CWP. To ensure your code works
+Please familiarise yourself with the [CWP recipes](03_Recipes_and_supported_modules.md) before starting to develop on CWP. To ensure your code works
 smoothly with the platform it's important to either start from the stable release of
 [cwp-installer](https://github.com/silverstripe/cwp-installer) or include
-your desired [CWP recipes](recipes_and_supported_modules) in your `composer.json`.
+your desired [CWP recipes](03_Recipes_and_supported_modules.md) in your `composer.json`.
 
-<div class="alert alert-info" markdown='1'>
 To ensure security of your site, and of CWP in general, please make sure your code can be easily upgraded by 
 maintaining your modules using composer. This will help to keep your dependencies updated with respect to the patch and 
-sub-patch versions of the recipe - read more about [CWP recipes](recipes_and_supported_modules).
-</div>
+sub-patch versions of the recipe - read more about [CWP recipes](03_Recipes_and_supported_modules.md).
 
 Another reason why it's best to maintain your modules using composer is that this will allow you to easily share the
-code with other agencies and enable easier upgrades. See [working with modules](working_with_modules)
+code with other agencies and enable easier upgrades. See [working with modules](06_Working_with_modules.md)
 for more information. If you decide to remove the `composer.json` file and instead commit the modules into the project code, we may not be able to support you because we will have to assume the modules have been customised.
 
 ## Server Configuration
@@ -31,7 +29,7 @@ for more information. If you decide to remove the `composer.json` file and inste
 You'll need an environment following SilverStripe's
 [server requirements](https://docs.silverstripe.org/en/4/getting_started/server_requirements/).
 
-CWP's configuration is detailed in [infrastructure considerations](infrastructural_considerations).
+CWP's configuration is detailed in [infrastructure considerations](11_Infrastructural_considerations.md).
 
 ## Git
 
@@ -90,6 +88,6 @@ on your machine using the software built by a company called GitHub (not related
 ## Where to from here?
 
 For people seasoned with SilverStripe development you can try jump-starting your development activities with the
-[getting started](/getting_started) guide.
+[getting started](../00_Getting_started.md) guide.
 
-For more information on correctly setting up your CWP project see [Setting up your project](setting_up_your_project). It shows how to set up Git and how to access GitLab to manage your code repositories on the CWP platform.
+For more information on correctly setting up your CWP project see [Setting up your project](01_Setting_up_your_project.md). It shows how to set up Git and how to access GitLab to manage your code repositories on the CWP platform.

--- a/docs/en/01_Working_with_projects/01_Setting_up_your_project.md
+++ b/docs/en/01_Working_with_projects/01_Setting_up_your_project.md
@@ -5,9 +5,9 @@ summary: Getting started with git version control and GitLab code management too
 
 ## Development environment
 
-See [Setting up a development environment](/working_with_projects/setting_up_a_development_environment).
+See [Setting up a development environment](../01_Working_with_projects/00_Setting_up_a_development_environment.md).
 
-The below relates to the use of a GitLab CWP hosted repository. If you have [migrated to a GitHub Git repository](/working_with_projects/setting_up_your_project/#making-your-first-project-commit-2), [start here](https://help.github.com/articles/cloning-a-repository/).
+The below relates to the use of a GitLab CWP hosted repository. If you have [migrated to a GitHub Git repository](../01_Working_with_projects/01_Setting_up_your_project.md/#making-your-first-project-commit), [start here](https://help.github.com/articles/cloning-a-repository/).
 
 ## Accessing GitLab
 GitLab is the code management tool you'll use when working with code changes to your SilverStripe CMS website on the Common Web Platform.
@@ -22,10 +22,10 @@ When accessing GitLab you'll see a page like this (below). On the right hand sid
 access to. Access a project from here to find more information including the repository URL details:
 
 #### GitLab projects overview
-![GitLab projects](/_images/gitlab-projects.jpg)
+![GitLab projects](../_images/gitlab-projects.jpg)
 
 #### Project details
-![GitLab project repository URL](/_images/gitlab-project-repo-url.jpg)
+![GitLab project repository URL](../_images/gitlab-project-repo-url.jpg)
 
 1. Now that you have the repository URL for the project, you can check it out in your development environment with the 
 following command:
@@ -42,15 +42,13 @@ following command:
 
     `composer install`
 
-This may take some time to run. There is some more information on these steps in the [Getting Started guide](../getting_started).
+This may take some time to run. There is some more information on these steps in the [Getting Started guide](../00_Getting_started.md).
 
-<div class="alert alert-info" markdown='1'>
-Assuming you followed through the "Setting up an development environment" guide, you can skip straight to "[Accessing the site](../working_with_projects/setting_up_your_project#accessing-the-site-2)" now.
-</div>
+Assuming you followed through the "Setting up an development environment" guide, you can skip straight to "[Accessing the site](../01_Working_with_projects/01_Setting_up_your_project.md#accessing-the-site)" now.
 
 ### Creating a new project?
 The preferred way to set up a new repository is to use the
-[cwp-installer](https://github.com/silverstripe/cwp-installer) module via Composer. Follow the instructions at [Getting Started](../getting_started) which will step you through how to create a project from scratch.
+[cwp-installer](https://github.com/silverstripe/cwp-installer) module via Composer. Follow the instructions at [Getting Started](../00_Getting_started.md) which will step you through how to create a project from scratch.
 
 ## Making your first project commit
 You will need to make your first commit to Git and push your project into your Git repository provided on GitLab when you signed up for CWP.
@@ -90,10 +88,8 @@ Your team should now be able to commence development on the project.
 At this stage you should be able to run the website on the default theme included in this recipe locally by visiting it
 in your browser (assuming that your LAMP stack is properly configured).
 
-<div class="hint" markdown='1'>
 You might need to configure your admin access credentials in the `.env` file to be able to access the
 site (see [environment management](https://docs.silverstripe.org/en/4/getting_started/environment_management/) docs).
-</div>
 
 ## Structure of the project
 The CWP recipe codebase includes the following directories that are either part of your `Project`, committed into Git or managed via `Composer`.
@@ -114,9 +110,9 @@ You have now a private repository that you can modify. Here is a list of likely 
  * Editing the name of the project in the root `composer.json` - find the **name** entry and change it so it's in the
 format of "my-agency/basic" - "cwp" namespace is reserved for platform-endorsed modules and recipes.
  * Customising the `mysite/_config.php` to configure your project.
- * [Customise the theme](customising_the_starter_theme/)
+ * [Customise the theme](05_Customising_the_starter_theme.md)
  * Writing new project features
- * [Adding more modules](working_with_modules)
+ * [Adding more modules](06_Working_with_modules.md)
  * Do any other housekeeping as necessary, for example edit or remove the `README` file.
 
 ## Troubleshooting

--- a/docs/en/01_Working_with_projects/02_Maintaining_your_code.md
+++ b/docs/en/01_Working_with_projects/02_Maintaining_your_code.md
@@ -10,7 +10,7 @@ Let's step through best practices in building your CWP site that will yield the 
 We recommend to start your development by installing via the [cwp-installer](https://github.com/silverstripe/cwp-installer) using Composer.
 This already sets up a reasonable structure to your site that will make future maintenance easier.
 
-See [Setting up your project](setting_up_your_project).
+See [Setting up your project](01_Setting_up_your_project.md).
 
 ## Using the CWP modules
 
@@ -18,7 +18,7 @@ Starting with the installer will also imply you use `cwp/cwp` and `cwp/cwp-core`
 This is where the updates to dependencies and essential code required for running your website on CWP infrastructure will be
 made available. It will make it much easier to keep your SilverStripe CMS up to date and take advantage of new feature if you use these modules as the basic of your website.
 
-See [Recipes and supported modules](recipes_and_supported_modules) for more details.
+See [Recipes and supported modules](03_Recipes_and_supported_modules.md) for more details.
 
 ## Maintaining modules using Composer
 
@@ -30,7 +30,7 @@ This makes it easy to maintain the site by switching module versions at desired 
 Dashboard (our deployment tool) will never modify the module versions listed in `composer.lock`, so it's up to the
 site developer to choose right versions via `composer.json`, and to run `composer update` at the right moments. Ensure you test updated modules thoroughly before deploying a new `composer.lock` file.
 
-You can also create private modules in GitLab for even better modularity. See [working with modules](working_with_modules)
+You can also create private modules in GitLab for even better modularity. See [working with modules](06_Working_with_modules.md)
 for more information on module creation, inclusion and sharing.
 
 ## Security patches
@@ -41,6 +41,6 @@ receive immediate security patches.
 This is relatively easy - if your `composer.json` is configured as in the installer, it should be as easy as running
 `composer update`, doing a smoke test and pushing to the upstream Git remote. See the [Upgrading](upgrading) guide for instructions.
 
-See [Recipes and supported modules](recipes_and_supported_modules) for more information on versioning and on how to keep your stacks secure.
+See [Recipes and supported modules](03_Recipes_and_supported_modules.md) for more information on versioning and on how to keep your stacks secure.
 
-See [infrastructural considerations](infrastructural_considerations) for hints on how to keep your stacks stable.
+See [infrastructural considerations](11_Infrastructural_considerations.md) for hints on how to keep your stacks stable.

--- a/docs/en/01_Working_with_projects/03_Recipes_and_supported_modules.md
+++ b/docs/en/01_Working_with_projects/03_Recipes_and_supported_modules.md
@@ -38,9 +38,7 @@ and assets.
 * [Hybrid Sessions](https://github.com/silverstripe/silverstripe-hybridsessions) - The module adds a hybrid cookie/database session store for SilverStripe
 * [MIME Upload Validator](https://github.com/silverstripe/silverstripe-mimevalidator) - The module checks that uploaded file content roughly matches a known MIME type for the file extension
 
-<div class="alert alert-info" markdown='1'>
 Note, that this recipe is required if you are running an Active Disaster Recovery (DR) instance. Find out more about [preparing your site for active DR](/how_tos/preparing_your_site_for_active_dr).
-</div>
 
 ### [CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms) 
 
@@ -131,11 +129,9 @@ Adds API and content service modules to your SilverStripe project. It includes t
 * [SilverStripe RestfulServer](https://github.com/silverstripe/silverstripe-restfulserver) - The RestfulServer module for SilverStripe CMS; it adds REST API capability
 * [Version Feed](https://github.com/silverstripe/silverstripe-versionfeed) - The module provides an RSS feed for global site changes
 
-<div class="alert alert-info" markdown='1'>
 Note, when installing the Services Recipe you will also install 
 [the GraphQL module](https://github.com/silverstripe/silverstripe-graphql) which is bundled with the core SilverStripe
 4 CMS. You may choose to use this over RestfulServer.
-</div>
 
 ## Recipe combinations
 
@@ -153,10 +149,8 @@ There are two themes provided for the Common Web Platform 2.0 that help governme
 * The [**CWP Starter theme**](https://github.com/silverstripe/cwp-starter-theme) is a developer focused highly accessible Bootstrap 3 theme. It is suited for sites that require more customisation and a design applied with minimal restrictions.
 * The [**Wātea theme**](https://github.com/silverstripe/cwp-watea-theme) includes more design elements than the CWP Starter theme. It is well suited for smaller agencies with smaller sites, smaller budgets and less developer involvement.
 
-<div class="alert alert-info" markdown='1'>
 The Wātea theme is a more "designed" subtheme which can be installed over the top of the Starter theme to provide a 
 more visually appealing starter project. It also requires the [CWP Agency Extensions Module](https://github.com/silverstripe/cwp-agencyextensions) to be installed.
-</div>
 
 ## Stabilising the project
 
@@ -224,7 +218,7 @@ The CWP support team may in some situations hot-patch (possibly in a destructive
 found to endanger other sites on the CWP infrastructure. The timeframe in which this could happen will be specified on the release
 notification.
 
-See the [upgrading guide](upgrading) for instructions.
+See the [upgrading guide](08_Upgrading.md) for instructions.
 
 ## Recipe contents
 

--- a/docs/en/01_Working_with_projects/04_Customising_the_default_functionality.md
+++ b/docs/en/01_Working_with_projects/04_Customising_the_default_functionality.md
@@ -80,10 +80,8 @@ Because all page types extend from `Page`, this will apply the editor field to *
 If you want your field to be a plain text area field instead, simply replace `HTMLText` with `Text` and
 `HtmlEditorField` with `TextareaField`.
 
-<div class="alert alert-info" markdown='1'>
 The "RichLinks" part of the template variable provides additional processing to the links in the content.
-[See more on the rich links functionality](cwp-features/rich_links).
-</div>
+[See more on the rich links functionality](../02_Features/rich_links.md).
 
 ## Customising the WYSIWYG editor
 

--- a/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md
+++ b/docs/en/01_Working_with_projects/05_Customising_the_starter_theme.md
@@ -17,9 +17,7 @@ not used.
 
 We recommend you follow the CWP Starter theme as a guideline and use the provided npm configuration to build and recompile your frontend dependencies.
 
-<div class="alert alert-info" markdown='1'>
 Note: The Starter theme is the default CWP theme as of the CWP 1.6 recipe. If you are looking for the old "default" CWP theme, [please see here](https://www.cwp.govt.nz/developer-docs/en/1.5/working_with_projects/customising_the_default_theme/).
-</div>
 
 ## Getting Started
 
@@ -89,7 +87,7 @@ That will have you set up with your own copy of the theme in the folder `/themes
 theme with others by adding them as team members to your project, or even making the repository public.
 
 Note the `"private": "true"` switch for your custom theme - this switch is needed to be able to deploy non-public,
-GitLab hosted modules. See [Working with modules](working_with_modules) for more information on this features.
+GitLab hosted modules. See [Working with modules](06_Working_with_modules.md) for more information on this features.
 
 ### Committing a theme to your project repository
 
@@ -111,9 +109,7 @@ also don't want to have access to your site's code as well, and will make it mor
  If you're using the public webroot feature (enabled by default from CWP 2.0 onwards) ensure you add your custom theme
   _after_ `'$public'`.
 
-<div class="alert alert-info" markdown='1'>
 Don't forget to `flush` by visiting `http://localhost/your-project/?flush=1` to get the new theme running!
-</div>
 
 Commit all changed files to your project repository so other collaborators can see it. This will include `composer.lock` file
 that "freezes" the current version of the modules to the ones you have currently included.
@@ -252,9 +248,7 @@ And add the following to src/scss/main.scss:
 
 You can follow the same process for Javascript files - take a look at the existing components for examples.
 
-<div class="alert alert-info" markdown='1'>
 It's generally encouraged to use Sass variables wherever possible. You can find a list of all predefined variables and values in the src/scss/variables.scss file. This file is based on the default Bootstrap 3 variable sheet, with some changes made and some new variables added.
-</div>
 
 Once you have added the new components, changed styles etc, you should run `npm run build` to compile and produce the "dist" files. On successful completion you can add and commit your updates files.
 

--- a/docs/en/01_Working_with_projects/06_Working_with_modules.md
+++ b/docs/en/01_Working_with_projects/06_Working_with_modules.md
@@ -7,10 +7,8 @@ Public (or private) modules are available as separate repositories (projects) wi
 
 We assume here that you have your website project already started, based off the basic recipe.
 
-<div class="hint" markdown='1'>
 Note: Both your main project (the website) and each of the modules have their own repositories. The main project is
 special in the sense that it has its own code *and* also pulls in other modules and places them in its root.
-</div>
 
 ## Creating a new module
 
@@ -44,14 +42,12 @@ requirement):
 }
 ```
 
-<div class="alert alert-info" markdown='1'>
 Please change the module name and namespace. The first part of the "name" in the `composer.json` file constitutes a
 namespace - please use the same namespace that you are using in Gitlab, to distinguish between the officially supported
 CWP modules (that reside in the "cwp" namespace) and private modules.
-</div>
 
 After your module is running and tested, you can publish it. Since your module is a self-contained piece of software, it
-will constitute a project in itself. From your module directory follow the instructions at [Creating repositories](/how_tos/creating_repositories).
+will constitute a project in itself. From your module directory follow the instructions at [Creating repositories](../03_How_tos/creating_repositories.md).
 
 Now push your module to the upstream, to the empty repository just created:
 
@@ -61,17 +57,14 @@ Now push your module to the upstream, to the empty repository just created:
 	git remote add origin https://gitlab.cwp.govt.nz/mateusz/foobar.git
 	git push -u origin master
 
-<div class="alert alert-info" markdown='1'>
 If you are pushing to an externally hosted GitHub repository, note that you will need to add the appropriate GitHub remote URL eg:
-
 `git remote add origin git@github.com:myprivate/repo.git`
-</div>
 
 Once the module is pushed to the repository you should see the code on Gitlab. From now on it will be available for
 others to clone, as long as they have at least a "Reporter" level access (see the note below though: private modules are
 not deployable).
 
-Check out instructions at [Sharing repositories](/how_tos/sharing_projects) on how to control module access
+Check out instructions at [Sharing repositories](../03_How_tos/sharing_projects.md) on how to control module access
 settings.
 
 ## Including a module in your project
@@ -95,10 +88,8 @@ root directory of your main project.
 		}
 	]
 
-<div class="alert alert-info" markdown='1'>
 The `private` parameter is non-standard and is used by Dashboard to distinguish between private repositories and
 public repositories. See the section below about public modules.
-</div>
 
 To include a private GitHub hosted module, for our *foobar* module pushed to an upstream GitHub repository, add the following lines to your `composer.json` file in the root directory of your main project.
 
@@ -110,9 +101,7 @@ To include a private GitHub hosted module, for our *foobar* module pushed to an 
 		}
 	]
 
-<div class="alert alert-info" markdown='1'>
 The `no-api` parameter prevents API usage which will remove the need for an API token from the CWP deployment systems.
-</div>
 
 This will add the repository to the list of URLs composer checks when updating the project dependencies. Hence you can
 now include the following requirement in the same `composer.json`:
@@ -130,12 +119,10 @@ we don't need to version-control it through the master repository.
 Run `composer update` to pull the module in and update all other dependencies as well. You can also update just this one
 module by calling `composer update <modulename>`.
 
-<div class="alert alert-info" markdown='1'>
 If you get cryptic composer errors it's worth checking that your module code is fully pushed. This is because composer
 can only access the code you have actually pushed to the upstream repository and it may be trying to use the stale
 versions of the files. Also, update composer regularly (`composer self-update`). You can also try deleting Composer
 cache: `rm -fr ~/.composer/cache`.
-</div>
 
 Finally, commit the the modified `composer.json`, `composer.lock`  and `.gitignore` files to the repository. The
 `composer.lock` serves as a snapshot marker for the dependencies - other developers will be able to `composer install`
@@ -149,12 +136,10 @@ If you decide to include private modules in your website project (also your own 
 will need a permission to access them. If you already have your repository associated with the stack you will be
 deploying to, the only thing you need to do is to enable the project key on the module as shown on the image below. The
 key is named after your stack identifier.
-![Gitlab - private repository deploy access](/_images/gitlab-private-repository-deploy-access.png)
+![Gitlab - private repository deploy access](../_images/gitlab-private-repository-deploy-access.png)
 
-<div class="alert alert-info" markdown='1'>
-You will only see the deployment key if you are the owner of the repository. See [deploying code](deploying-code) for
+You will only see the deployment key if you are the owner of the repository. See [deploying code](07_Releasing.md) for 
 more information.
-</div>
 
 Also, double check that your project's `composer.json` specifies the "private" parameter for all private repositories as
 shown in the "Including a module in your project" section.
@@ -168,4 +153,4 @@ will then be available to you in the project settings.
 1. Select the project and click "Project Settings" on the left menu
 2. Inside settings, choose the correct "Visibility Level" and click "Save changes"
 
-![Gitlab - making the repository public](/_images/gitlab-making-repository-public.jpg)
+![Gitlab - making the repository public](../_images/gitlab-making-repository-public.jpg)

--- a/docs/en/01_Working_with_projects/08_Upgrading.md
+++ b/docs/en/01_Working_with_projects/08_Upgrading.md
@@ -4,7 +4,7 @@ summary: Guidance on upgrading your website for new CWP recipe releases.
 # Upgrading
 
 Assuming that you have followed the approach outlined in the tutorials, upgrading to new patch and sub-patch versions
-of the recipe shouldn't take long time. See [recipes and supported modules](recipes_and_supported_modules) documentation to learn more about how recipe
+of the recipe shouldn't take long time. See [recipes and supported modules](03_Recipes_and_supported_modules.md) documentation to learn more about how recipe
 versioning is structured.
 
 ## Point upgrades
@@ -73,12 +73,10 @@ You will know you need to migrate your project if you see the following configur
 
 This long list of dependencies should no longer be pulled in directly. Here is how to fix this for the future.
 
-<div class="alert alert-info" markdown='1'>
 If you have customised the original project based on recipe-basic by removing/changing versions of modules you will
 notice this migration will force you to pull these back via the new cwp-recipe-basic metapackage. This is intended -
 the only code supported by the CWP Team is the mix of modules present in the latest stable release of the
 `cwp/cwp-recipe-basic` module.
-</div>
 
 First, identify the list of modules which you have added to the project. In the above example this is represented as
 `my-agency/my-dependency` - these need to be kept. All the remaining original dependencies must be stripped off
@@ -129,7 +127,7 @@ excluded (as the project already provides its own theme):
 
 Links:
 
-* [CWP releases and changelogs](/releases_and_changelogs)
+* [CWP releases and changelogs](../05_Releases_and_changelogs)
 * [old, unsupported composer.json](https://gitlab.cwp.govt.nz/cwp/recipe-basic/blob/1.0.0/composer.json) from
 deprecated `cwp/recipe-basic` module
 * [new, recommended composer.json](https://github.com/silverstripe/cwp-installer/blob/master/composer.json) from the new

--- a/docs/en/01_Working_with_projects/10_Security.md
+++ b/docs/en/01_Working_with_projects/10_Security.md
@@ -94,7 +94,7 @@ Uploaded files have their extension checked against known MIME types in the `HTT
 This basically means the file contents are checked to ensure the extension matches. For example, if you rename an image
 `test.jpg` to `test.txt` and attempt to upload it, the file will be rejected.
 
-Please see [technical docs for adding extensions](how-tos/adding_an_allowed_extension) for more information on
+Please see [technical docs for adding extensions](../03_How_tos/adding_an_allowed_extension.md) for more information on
 allowing new file extensions and MIME types.
 
 ### Front-end authentication

--- a/docs/en/01_Working_with_projects/11_Infrastructural_considerations.md
+++ b/docs/en/01_Working_with_projects/11_Infrastructural_considerations.md
@@ -8,7 +8,7 @@ summary: Aspects of the CWP server environment infrastructure to be aware of whe
 The high level CWP infrastructure is outlined on cwp.govt.nz.
 More detail is available through a solution architecture document on request
 to participating agencies. See [technical and architecture information](https://www.cwp.govt.nz/about/technical-and-architecture-information/).
-Please review our [Performance Guide](/performance-guide/index)
+Please review our [Performance Guide](../04_Performance_Guide/index.md)
 for recommendations on how to use the available infrastructure efficiently.
 
 ## HTTP request time limit
@@ -21,17 +21,15 @@ has a HTTP request timeout limit of 120 seconds, after which it will
 generate a 504 (Gateway Timeout) error.
 This is preventing overloading of the shared parts of the infrastructure.
 
-<div class="alert alert-warning" markdown='1'>
 Your publicly accessible URLs should never take a long time to process, as this leaves your environment open to denial of
 service attacks. You should definitely hide these behind a login or a captcha, or use caching and other optimisations
 to bring down the processing time.
-</div>
 
 The preferred way to handle your long-running processes is via the 
 [queuedjobs](https://github.com/symbiote/silverstripe-queuedjobs) module. 
 You can extend the time limit of a PHP process by using the SilverStripe Framework APIs `\SilverStripe\Core\Environment::increaseTimeLimitTo()`.
 
-Consider using [caching](/performance-guide/caching) to speed up request execution.
+Consider using [caching](../04_Performance_Guide/01_Caching.md) to speed up request execution.
 
 ## PHP configuration
 
@@ -60,7 +58,7 @@ These PHP extensions are part of the standard environment, and can be relied on 
 ## Webserver
 
 CWP environments are running Apache 2.4 (see Debian "Jessie" [packages](https://packages.debian.org/jessie/)).
-Note that there's other [caching infrastructure](/performance_guide/caching) in front of your CWP environment.
+Note that there's other [caching infrastructure](../04_Performance_Guide/01_Caching.md) in front of your CWP environment.
 
 ## Database
 
@@ -89,11 +87,11 @@ support
 
 ## Other features
 
- * [Varnish and Incapsula caching](/performance_guide/http_caching)
- * [Outgoing HTTP proxy](/how_tos/external_http_requests_with_proxy)
+ * [Varnish and Incapsula caching](../04_Performance_Guide/02_HTTP_Caching.md)
+ * [Outgoing HTTP proxy](../03_How_tos/external_http_requests_with_proxy.md)
  * [WKHTMLTOPDF](http://wkhtmltopdf.org/) is available in series 0.12.4.
- * [Solr search](/features/solr_search)
- * [Apache Tika](/features/solr_search/searching_documents)
+ * [Solr search](../02_Features/01_Solr_search)
+ * [Apache Tika](../02_Features/01_Solr_search/07_Searching_documents.md)
 
 ## Process for new infrastructure features
 

--- a/docs/en/01_Working_with_projects/13_Centralised_logging.md
+++ b/docs/en/01_Working_with_projects/13_Centralised_logging.md
@@ -70,7 +70,7 @@ bootstrap. This includes uncaught exceptions and any `Injector::inst()->get(Logg
 Graylog provides several tools to analyse your search results. To analyse a 
 field from your search results, expand the field in the search sidebar and click
 on the button of the analysis you want to perform.
-![search analysis](/_images/logs/search_analysis.png)
+![search analysis](../_images/logs/search_analysis.png)
 
 ### Field statistics
 
@@ -82,7 +82,7 @@ deviation, variance, sum, and cardinality. On non-numeric fields, you can only
 see the total amount of messages containing that field, and the cardinality of
 the field, i.e. the number of unique values it has.
 
-![field_statistics](/_images/logs/field_statistics.png)
+![field_statistics](../_images/logs/field_statistics.png)
 
 ### Quick values
 You can use quick values to help you find out the distribution of values for a field. 
@@ -90,7 +90,7 @@ Alongside a graphic representation of the common values contained in a field,
 Graylog will display a table with all different values, allowing you to see the
 number of times they appear. You can include any value in your search query by
 clicking on the magnifying glass icon located in the value row.
-![quick values](/_images/logs/quick_values.png)
+![quick values](../_images/logs/quick_values.png)
 
 ### Field graphs
 You can create field graphs for any numeric field, by clicking on the Generate
@@ -99,7 +99,7 @@ top of the field graph, you can change the statistical function used in the
 graph, the kind of graph to use to represent the values, the graph
 interpolation, as well as the time resolution.
 
-![field graphs](/_images/logs/field_graph.png)
+![field graphs](../_images/logs/field_graph.png)
 
 For more information see [Graylog analysis documentation](http://docs.graylog.org/en/stable/pages/queries.html#analysis).
 

--- a/docs/en/01_Working_with_projects/14_Using_the_Watea_theme.md
+++ b/docs/en/01_Working_with_projects/14_Using_the_Watea_theme.md
@@ -4,7 +4,7 @@ introduction: Describes how to use the CWP Wātea theme
 
 # Using the Wātea theme
 
-[The Wātea theme](https://github.com/silverstripe/cwp-watea-theme) is a more "designed" [cascading theme](https://docs.silverstripe.org/en/4/developer_guides/templates/themes) which can be installed over the top of the [CWP Starter theme](customising_the_starter_theme) to provide a more visually appealing starter project.
+[The Wātea theme](https://github.com/silverstripe/cwp-watea-theme) is a more "designed" [cascading theme](https://docs.silverstripe.org/en/4/developer_guides/templates/themes) which can be installed over the top of the [CWP Starter theme](05_Customising_the_starter_theme.md) to provide a more visually appealing starter project.
 
 ## Installation
 
@@ -20,7 +20,7 @@ The installation of `cwp/agency-extensions` is suggested as it provides addition
 
 ## Getting started
 
-This theme is designed to augment the base functionality and framework provided by the [CWP Starter theme](https://github.com/silverstripe/cwp-starter-theme). As such, [all of the documentation for the CWP Starter theme](customising_the_starter_theme) is relevant to this theme as well. We suggest you familiarise yourself with this documentation.
+This theme is designed to augment the base functionality and framework provided by the [CWP Starter theme](https://github.com/silverstripe/cwp-starter-theme). As such, [all of the documentation for the CWP Starter theme](05_Customising_the_starter_theme.md) is relevant to this theme as well. We suggest you familiarise yourself with this documentation.
 
 As a general rule, the CWP Team have endeavoured to constrain changes for this theme to CSS and Javascript wherever 
 possible, as opposed to modifying and duplicating the templates. As a cascading theme, all templates in this theme will 
@@ -30,13 +30,11 @@ If you need to modify template markup from the SilverStripe framework, other mod
 
 ## Development
 
-<div class="alert alert-info" markdown='1'>
-Please familiarise yourself with [Customising the starter theme](customising_the_starter_theme), as all documentation there is relevant for this subtheme as well.
-</div>
+Please familiarise yourself with [Customising the starter theme](05_Customising_the_starter_theme.md), as all documentation there is relevant for this subtheme as well.
 
 ### Setup
 
-For development you will need Node.js and npm installed. Please see the [Customising the starter theme](customising_the_starter_theme) article for more information.
+For development you will need Node.js and npm installed. Please see the [Customising the starter theme](05_Customising_the_starter_theme.md) article for more information.
 
 Next, you need to install the required npm packages. You will need to do this both in the CWP Starter theme and in the "starter_watea" subtheme, as this subtheme imports components from the "starter" theme during Sass building. Ensure you have changed each theme's directory first:
 
@@ -61,9 +59,8 @@ Or to "watch" for changes in real time as you develop (faster):
 ```
 npm run watch  # Compiles as "build", then watches for changes and recompiles as necessary
 ```
-<div class="alert alert-info" markdown='1'>
+
 Please note: This subtheme's compiled Javascript assets are only relevant to this theme, and should be applied on top of the CWP Starter theme's assets. Ensure that you include them in the correct order.
-</div>
 
 For CSS, this theme contains _a fully compiled_ set of styles for both themes. You should only include this theme's CSS (not the CWP Starter theme).
 
@@ -89,4 +86,4 @@ npm run lint-js
 npm run lint-sass
 ```
 
-For information on the rules and configuration around these linters, please see the [CWP Starter theme](customising_the_starter_theme) documentation regarding "working with standards".
+For information on the rules and configuration around these linters, please see the [CWP Starter theme](05_Customising_the_starter_theme.md) documentation regarding "working with standards".

--- a/docs/en/02_Features/00_Pre_configuration.md
+++ b/docs/en/02_Features/00_Pre_configuration.md
@@ -5,7 +5,7 @@ introduction: The CWP recipe codebase includes two modules that pre-configure yo
 # Pre-configuration of CWP recipe codebase
 
 The default SilverStripe CMS codebase used on the CWP infrastructure is referred to as the ["CWP CMS recipe"](/working_with_projects/recipes_and_supported_modules).
-When starting a new CWP project based on the [`cwp/cwp-installer`](/getting_started) custom SilverStripe CMS installer for CWP, a
+When starting a new CWP project based on the [`cwp/cwp-installer`](/00_Getting_started.md) custom SilverStripe CMS installer for CWP, a
 selection of pre-configured modules are included (we've done the work for you as you would usually have to configure
 these modules yourself) and provide a set of standardised features for Government agencies. Some of this
 configuration is mandatory in order for your website to operate correctly on the CWP servers, while others

--- a/docs/en/02_Features/01_Solr_search/00_Configuration.md
+++ b/docs/en/02_Features/01_Solr_search/00_Configuration.md
@@ -14,7 +14,7 @@ You must satisfy the following requirements to successfully connect to the share
 
 Your project will be configured automatically by the [cwp/cwp-search](https://github.com/silverstripe/cwp-search) module to resemble production infrastructure as much as possible. Currently CWP supports only Solr version 4.
 
-## Limitations and Acceptable Use Policy {#limitations}
+## Limitations and Acceptable Use Policy
 
 Solr on CWP is a shared service, and it comes with some limitations:
 
@@ -31,12 +31,12 @@ Solr on CWP is a shared service, and it comes with some limitations:
 ## Source Code
 
 The base `silverstripe/fulltextsearch` module source code is available at 
-[https://github.com/silverstripe/silverstripe-fulltextsearch](github.com/silverstripe/silverstripe-fulltextsearch)
+[https://github.com/silverstripe/silverstripe-fulltextsearch](https://github.com/silverstripe/silverstripe-fulltextsearch)
 
 ## CWP Integration
 
 The base `silverstripe/fulltextsearch` module is tightly integrated into the [CWP installer](https://github.com/silverstripe/cwp-installer)
-through the [cwp/cwp-recipe-search](github.com/silverstripe/cwp-search) recipe. You usually don't have to install anything extra.
+through the [cwp/cwp-recipe-search](https://github.com/silverstripe/cwp-search) recipe. You usually don't have to install anything extra.
 
 This module sets up:
 

--- a/docs/en/02_Features/01_Solr_search/01_Running_solr_locally.md
+++ b/docs/en/02_Features/01_Solr_search/01_Running_solr_locally.md
@@ -8,13 +8,11 @@ dependency in your top-level `composer.json` file.
 
 When selecting versions, make sure you use the version supported by CWP: `4.*@dev`.
 
-<div class="alert alert-info" markdown='1'>
 Older versions of *silverstripe-fulltextsearch* module used to bundle the Solr binary. You should check the version of this module before proceeding with this guide.
-</div>
 
 ## Differences to CWP
 
-Please read through the [Limitations and Acceptable Use Policy](configuration#limitations)
+Please read through the [Limitations and Acceptable Use Policy](00_Configuration.md#limitations-and-acceptable-use-policy)
 of running Solr in the CWP infrastructure. 
 
 Most importantly, CWP infrastructure enforces `solrconfig.xml` to ensure stability of the shared service.

--- a/docs/en/02_Features/01_Solr_search/04_Default_search_index.md
+++ b/docs/en/02_Features/01_Solr_search/04_Default_search_index.md
@@ -40,7 +40,5 @@ Please note that if you want to index other database fields or need to create a 
 
 *Note:* The line `$this->addFilterField('ShowInSearch');` is a standard requirement for all CWP recipe versions, and will need to be added to any custom indexes created.
 
-
-<div class="alert alert-info" markdown='1'>
 If you are using cwp recipe 1.1.0 or below please refer to [version 1.1 and before documentation archive](https://www.cwp.govt.nz/developer-docs/en/1.1/features/solr_search#default-search-index-2) for the index code
-</div>
+

--- a/docs/en/02_Features/01_Solr_search/05_Searching_dataobjects.md
+++ b/docs/en/02_Features/01_Solr_search/05_Searching_dataobjects.md
@@ -66,9 +66,7 @@ class MySolrSearchIndex extends CwpSearchIndex
 }
 ```
 
-<div class="alert alert-info" markdown='1'>
 If you are using cwp recipe 1.1.0 or below please refer to the [version 1.1 and before documentation archive](https://www.cwp.govt.nz/developer-docs/en/1.1/features/solr_search#adding-dataobject-classes-to-solr-search-2) for the index code
-</div>
 
 These are both implementations of the base configuration but with the addition of `StaffMember`.
 

--- a/docs/en/02_Features/01_Solr_search/07_Searching_documents.md
+++ b/docs/en/02_Features/01_Solr_search/07_Searching_documents.md
@@ -3,7 +3,7 @@ summary: How to configure Solr indexing and searching of documentation such as W
 
 # Searching within documents
 
-<div class="alert alert-info" markdown='1'>This feature requires cwp recipe 1.1.0 or above specifically the [textextraction](https://github.com/silverstripe-labs/silverstripe-textextraction) module</div>
+This feature requires cwp recipe 1.1.0 or above specifically the [textextraction](https://github.com/silverstripe-labs/silverstripe-textextraction) module
 
 By default all CWP environments have text extraction services configured. These services can be used by user code
 to transform text-based documents (such as PDF, MS Word, or rich text) into plain text in a format which can

--- a/docs/en/02_Features/blog_recipe.md
+++ b/docs/en/02_Features/blog_recipe.md
@@ -7,9 +7,7 @@ The SilverStripe blog module lets you publish blog posts and allow the public to
 engage with you by commenting on your posts. The module supports flexible
 categorisation and tagging of blog posts.
 
-<div class="alert alert-info" markdown='1'>
 From 1.1.0 onwards the `blog recipe` is included along side the other SilverStripe and CWP recipes by default.
-</div>
 
 [Three levels of permissions are supported](https://github.com/silverstripe/silverstripe-blog/blob/master/docs/en/userguide/roles.md):
 
@@ -18,13 +16,13 @@ From 1.1.0 onwards the `blog recipe` is included along side the other SilverStri
  * Contributors who can write, but have limited permissions otherwise
 
 Commenting can be enabled and disabled, and all comments go through a
-[spam filter](/how_tos/akismet) and then need to be manually moderated before
+[spam filter](../03_How_tos/akismet.md) and then need to be manually moderated before
 they are published. The module provides an RSS feed to allow the public to
 subscribe to your blog posts.
 
-![Blog CMS](/_images/blog_cms.png)
+![Blog CMS](../_images/blog_cms.png)
 
-![Blog Frontend](/_images/blog_frontend.png)
+![Blog Frontend](../_images/blog_frontend.png)
 
 ## Overview
 
@@ -65,7 +63,7 @@ customise the blog recipe for cwp defaults. These settings are included in the `
 blog.yml file under `mysite/_config`. Sites upgrading from 1.0.7 or below may require one or more of these settings
 to be manually added.
 
-For configuration of anti-spam please see the [Akismet configuration guide](/how_tos/akismet) for more information.
+For configuration of anti-spam please see the [Akismet configuration guide](../03_How_tos/akismet.md) for more information.
 
 For the basic configuration, see the default `mysite/_config/blog.yml` below for reference:
 

--- a/docs/en/02_Features/data_registry.md
+++ b/docs/en/02_Features/data_registry.md
@@ -9,8 +9,8 @@ download a CSV copy of the data for reuse.
 
 The SilverStripe CMS module used to provide this feature is the [`silverstripe/registry`](http://addons.silverstripe.org/add-ons/silverstripe/registry/) module. 
  
-<div class="alert alert-info" markdown='1'>This feature is **not** enabled by default in the CWP recipe and must be enabled by a developer first 
-before a CMS user can use it ([See the user documentation](https://userhelp.silverstripe.org/en/3.2/optional_features/online_databases_and_registries/)).</div>
+This feature is **not** enabled by default in the CWP recipe and must be enabled by a developer first 
+before a CMS user can use it ([See the user documentation](https://userhelp.silverstripe.org/en/3.2/optional_features/online_databases_and_registries/)).
 
 ## Enabling the data registry
 

--- a/docs/en/02_Features/pdf_export.md
+++ b/docs/en/02_Features/pdf_export.md
@@ -15,9 +15,7 @@ installed for this functionality to be enabled.
 A special `$PdfLink` variable is provided to the templates, which if applied as the value of an `href` value to an
 anchor in the template, will provide users with a way to download the a PDF version of the current page.
 
-<div class="alert alert-info" markdown='1'>
 This variable is commented out by default in the CWP Starter and Wātea themes. You can re-enable it by uncommenting these lines in `PageUtilities.ss`.
-</div>
 
 When the user requests a PDF of the page, the page is exported as HTML by SilverStripe and then passed along to
 `wkhtmltopdf` which generates a PDF of the HTML. The PDF is then stored in `assets/_generated_pdfs` and subsequent
@@ -38,7 +36,6 @@ viewing the website, there are no permission checks when accessing files directl
 
 ## Installation
 
-<div class="alert alert-info" markdown='1'>
 The CWP test and production servers you'll be deploying your site to already have `wkhtmltopdf` installed.
 These instructions are only necessary if you want to develop or use the PDF export functionality in your local
 development environment. Skip to [Enabling PDF export ...](#enabling-pdf-export-functionality) below if you simply want to enable the PDF export
@@ -46,7 +43,6 @@ functionality.
 
 The instructions below assume you're on a Debian or Ubuntu Linux environment.
 There is a Mac OS X download, and there may be a Windows binary for `wkhtmltopdf` but they have not been tested.
-</div>
 
 * [Download wkhtmltopdf](https://wkhtmltopdf.org/downloads.html) for your system type:
 

--- a/docs/en/02_Features/realme_authentication.md
+++ b/docs/en/02_Features/realme_authentication.md
@@ -7,7 +7,7 @@ The [RealMe module](https://github.com/silverstripe/silverstripe-realme/) enable
 government's preferred approach for website authentication, to deliver online services or restrict information to 
 specific people.
 
-<div class="alert alert-info" markdown='1'>This module is only supported from cwp recipe 1.2.0 and above.</div>
+This module is only supported from cwp recipe 1.2.0 and above.
 
 The module facilitates the log-on process; agencies need to work with the RealMe team to conduct the 
 integration, and will need to work with web developers to build whatever the system performs after you have logged in 
@@ -45,4 +45,4 @@ If there are any further questions, please don't hesitate to
 
 ## See Also
 
- * [Single sign-on via Active Directory](active_directory_single_sign_on)
+ * [Single sign-on via Active Directory](active_directory_single_sign_on.md)

--- a/docs/en/02_Features/translations.md
+++ b/docs/en/02_Features/translations.md
@@ -7,8 +7,8 @@ The [SilverStripe Fluent](https://github.com/tractorcow/silverstripe-fluent) mod
 multiple pages in various languages or locales within languages. This module also adds the ability for your users
 to select which language of a page they wish to view.
 
-<div class="alert alert-info" markdown='1'>The SilverStripe Fluent module does not translate content automatically, content
-authors will need to enter the translated content manually for each translated page.</div>
+The SilverStripe Fluent module does not translate content automatically, content
+authors will need to enter the translated content manually for each translated page.
 
 ## Setup
 

--- a/docs/en/03_How_tos/adding_a_calendar.md
+++ b/docs/en/03_How_tos/adding_a_calendar.md
@@ -116,12 +116,12 @@ We can also provide an alternative string if no events are found:
 
 We can already test this snippet of code (this is using the *default* theme and Bootstrap `well` and `span3` classes):
 
-![](/_images/calendar-empty.jpg)
+![](../_images/calendar-empty.jpg)
 
 If we have no current events, as in the previous example, we can test the code by switching to another month using the
 GET parameters. Let's try `?year=2013&month=1`.
 
-![](/_images/calendar-month.jpg)
+![](../_images/calendar-month.jpg)
 
 That's pretty good.
 
@@ -184,7 +184,7 @@ month. The `MonthName` is a three-letter shorthand for a month, such as "Apr".
 
 Here is how will the calendar appear with the month picker added in:
 
-![](/_images/calendar-picker.jpg)
+![](../_images/calendar-picker.jpg)
 
 ## Limiting the events in the calendar
 
@@ -210,7 +210,7 @@ return EventHolder::ExtractMonths(
 
 That will filter out events that are not marked as "Future".
 
-![](/_images/calendar-filtered-by-tag.jpg)
+![](../_images/calendar-filtered-by-tag.jpg)
 
 ## Code listing
 

--- a/docs/en/03_How_tos/creating_repositories.md
+++ b/docs/en/03_How_tos/creating_repositories.md
@@ -3,20 +3,20 @@ summary: How to create a new GitLab repository and grant access.
 
 # Creating a project/repository
 
-The below relates to the use of a GitLab CWP hosted repository. If you have [migrated to a GitHub Git repository](/working_with_projects/setting_up_your_project/#making-your-first-project-commit-2), [please refer to the GitHub documentation](https://help.github.com/).
+The below relates to the use of a GitLab CWP hosted repository. If you have [migrated to a GitHub Git repository](../01_Working_with_projects/01_Setting_up_your_project.md/#making-your-first-project-commit), [please refer to the GitHub documentation](https://help.github.com/).
 
 In Gitlab, a **Project** is also considered to be a repository.
 
 Create a new one by clicking the **New Project** button in the Gitlab **Dashboard**.
 
-![Gitlab New Project button on dashboard](/_images/gitlab-new-project.jpg)
+![Gitlab New Project button on dashboard](../_images/gitlab-new-project.jpg)
 
 ## Assigning access to the project
 
 The **Team** tab in your project view in Gitlab allows you to add new team members, import an entire team of other
 users to the project, or modify existing team member permissions to the project.
 
-![Gitlab Team tab for changing project access](/_images/gitlab-team-access.jpg)
+![Gitlab Team tab for changing project access](../_images/gitlab-team-access.jpg)
 
 There are different levels of access a user can have to your project.
 [Gitlab permissions help](https://gitlab.cwp.govt.nz/help/permissions/permissions.md) has more information on the levels of permission
@@ -31,4 +31,4 @@ This will mean anyone can `git checkout` your project.
 
 It will also be listed on the [Gitlab Public Projects](http://gitlab.cwp.govt.nz/public) list.
 
-![Setting public access in project settings](/_images/gitlab-public-project-setting.jpg)
+![Setting public access in project settings](../_images/gitlab-making-repository-public.jpg)

--- a/docs/en/03_How_tos/custom_embeds_in_the_WYSIWYG_editor.md
+++ b/docs/en/03_How_tos/custom_embeds_in_the_WYSIWYG_editor.md
@@ -6,12 +6,10 @@ summary: How to allow custom embeds in the TinyMCE HTML editor.
 This how-to guides developers through the steps necessary to disable default TinyMCE handling
 of the `<embed>` and `<object>` tags.
 
-<div class="alert alert-info" markdown='1'>
 Proceeding with this guide will disable the ability of the CMS to embed `.swf` files through the "Insert Media"
 interface button. You will need to provide your own 
 [custom TinyMCE plugins](https://docs.silverstripe.org/en/3.2/developer_guides/forms/field_types/htmleditorfield) or 
 embed the files directly via HTML code.
-</div>
 
 ## Disable the media plugin
 

--- a/docs/en/03_How_tos/error_logging.md
+++ b/docs/en/03_How_tos/error_logging.md
@@ -4,7 +4,7 @@ summary: How to set up email error logging in CWP environments.
 # Error logging
 
 Basic recipe is configured to send all logs to syslog, which are accessible through the
-[centralised logging system](/working_with_projects/centralised_logging/).
+[centralised logging system](../01_Working_with_projects/13_Centralised_logging.md).
 
 To send logs to email (in addition to syslog) add the following to your `mysite/_config.php`:
 

--- a/docs/en/03_How_tos/inspecting_audit_log.md
+++ b/docs/en/03_How_tos/inspecting_audit_log.md
@@ -17,5 +17,5 @@ related to your environment and search for:
 
 	log_type:SilverStripe_audit
 
-See the [centralised logging system](/working_with_projects/centralised_logging/) for more information on working
+See the [centralised logging system](../01_Working_with_projects/13_Centralised_logging.md) for more information on working
 with Graylog.

--- a/docs/en/03_How_tos/maintenance_screen.md
+++ b/docs/en/03_How_tos/maintenance_screen.md
@@ -10,12 +10,12 @@ In order to ensure that this error page is available, it's necessary to create *
 the appropriate error codes. Setup the following (as below) with the codes 500 and 503. This generates the
 `assets/error-500.html` and `assets/error-503.html`files necessary.
 
-![Creating an error page](/_images/creating-an-error-page.png)
+![Creating an error page](../_images/creating-an-error-page.png)
 
 These pages will be displayed to the user in the following situations:
 
-* [During server error or outage](#during-server-error-or-outage-2)
-* [During Deployment](#during-deployment-2)
+* [During server error or outage](#error-pages-during-server-error-or-outage)
+* [During Deployment](#error-pages-during-deployment)
 
 ## Error pages during server error or outage
 
@@ -31,7 +31,7 @@ Note that this page is normally created by default during install.
 During the course of certain deployment activities Dashboard will display the error-503.html page for the duration
 of the process.
 
-![Default maintenance screen](/_images/default-maintenance-screen.jpg)
+![Default maintenance screen](../_images/default-maintenance-screen.jpg)
 
 From the technical perspective, Dashboard creates temporary `.htaccess` and `maintenance.html` files. It assumes that
 the codebase comes with `.htaccess`, so this is renamed and stored for later retrieval. Websites must not create their

--- a/docs/en/03_How_tos/php_configuration.md
+++ b/docs/en/03_How_tos/php_configuration.md
@@ -1,4 +1,4 @@
 title: PHP Configuration
 summary: Details of the PHP version being used on CWP environments.
 
-See [infrastructural considerations](/working_with_projects/infrastructural_considerations).
+See [infrastructural considerations](../01_Working_with_projects/11_Infrastructural_considerations.md).

--- a/docs/en/03_How_tos/preparing_your_site_for_active_dr.md
+++ b/docs/en/03_How_tos/preparing_your_site_for_active_dr.md
@@ -19,11 +19,9 @@ Your custom domains will be actively load balanced between the two nodes. *.cwp.
  * stack-dr.cwp.govt.nz - points to Auckland
 
 
-<div class="alert alert-warning" markdown='1'>
 In other words, we can't make your site highly-available if your production domain is not pointing to CWP (i.e. your
 site is not live).  Additionally, accessing your site at any time through the "cwp.govt.nz" domain will not exhibit the
 highly-available property.
-</div>
 
 The following chapters provide information on the required changes to your code to ensure the site works correctly with
 Active Disaster Recovery.

--- a/docs/en/03_How_tos/sharing_projects.md
+++ b/docs/en/03_How_tos/sharing_projects.md
@@ -8,22 +8,22 @@ introduction: This how-to will show you how to share a repository with other Git
 
 You can add any user of the Gitlab site to one of your repositories.
 
-If you simply want to share some files, you could [create a new repository](creating_repositories) for these files
+If you simply want to share some files, you could [create a new repository](creating_repositories.md) for these files
 (note that changes to locked repositories by third parties require merge requests).
 
 Locate the repository that contains the files you wish to share and go to the Team tab.
 
 There are 2 options available to handle permissions:
 
-![Team Memberships](/_images/gitlab-team-home.png)
+![Team Memberships](../_images/gitlab-team-home.png)
 
 1. Import Members
     * This will allow you to import the team permissions from another project you have created.
-    ![Team Memberships](/_images/gitlab-team-copypermissions.png)
+    ![Team Memberships](../_images/gitlab-team-copypermissions.png)
     * From the *Project Access* drop down box select the project to copy the permissions from.
 2. Add Members
     * This will allow you to assign permissions to the repository to another Gitlab user
-    ![Team Memberships](/_images/gitlab-team-newuser.png)
+    ![Team Memberships](../_images/gitlab-team-newuser.png)
     * Either type the name of the user or select from the drop down box.
     * Select the access level required:
         1. Guest

--- a/docs/en/03_How_tos/using_content_migration_tools.md
+++ b/docs/en/03_How_tos/using_content_migration_tools.md
@@ -22,6 +22,6 @@ Drupal
 
 A screenshot of the HTML importer is shown here:
 
-![screenshot of HTML importer](/_images/html-importer-screenshot.jpg)
+![screenshot of HTML importer](../_images/html-importer-screenshot.jpg)
 
 You can also commission SilverStripe for assistance in migrating websites, for example to tailor the migration tool to support a legacy system you use, or to re-implement features from your old website on the Common Web Platform.

--- a/docs/en/04_Performance_Guide/00_Performance_Testing.md
+++ b/docs/en/04_Performance_Guide/00_Performance_Testing.md
@@ -9,11 +9,9 @@ If you are migrating an existing site, analysis of the access logs will help you
 such as the most commonly accessed pages, sections, or user behaviours. A great tool for a visual representation of your
 log data is [GoAccess](https://goaccess.io/).
 
-<div class='alert alert-warning'>
 Be wary of using Google Analytics as a source of your most-hit URLs - they don't include bot visitors, which can end up
 skewing your traffic a long way towards URLs that you would not expect. This is also why you should take your pageviews
 statistic with a grain of salt if it comes from Google Analytics - access logs are the truest record.
-</div>
 
 If you are building a site from scratch, there are a few good rules of thumb for pages to test:
 
@@ -69,4 +67,4 @@ Generally this will be performed by a specialist testing company.
 
 ## Next
 
-Continue to our [Overview on Caching](caching).
+Continue to our [Overview on Caching](01_Caching.md).

--- a/docs/en/04_Performance_Guide/01_Caching.md
+++ b/docs/en/04_Performance_Guide/01_Caching.md
@@ -19,7 +19,7 @@ In SilverStripe there are several patterns that are used frequently that are qui
  * Using (potentially large) relation getters on `DataObject` (has_many and many_many)
  * Nesting relation getters within loops on large `DataList` collections
  * Using expensive SQL join operations
- * Network calls to third party services (see [Deferring Work](deferring_work))
+ * Network calls to third party services (see [Deferring Work](03_Deferring_Work.md))
  * Frequent filesystem access
 
 We'll describe common caching approaches below. You'll want to apply a layered approach to
@@ -28,11 +28,11 @@ caching to get the best results, and combine multiple approaches.
 ## HTTP Caching in the browser
 
 The fastest server request is one that's never made.
-With the correct use of [HTTP Caching](http_caching), resources can be stored by browsers for a defined amount of time.
+With the correct use of [HTTP Caching](02_HTTP_Caching.md), resources can be stored by browsers for a defined amount of time.
 This applies both to "static" resources likes images and JavaScript files, as well as dynamic requests coming from SilverStripe.
 Client-side caching will reduce load on your site as well as loading times for your end users.
 
-Read more about [Frontend Performance Best Practices](frontend_best_practices) in our CWP Performance Guide.
+Read more about [Frontend Performance Best Practices](04_Frontend_Best_Practices.md) in our CWP Performance Guide.
 
 ## HTTP Caching on the server
 
@@ -42,7 +42,7 @@ If your site serves the same content to all visitors, this is the easiest way to
 You can only cache a full response, so this approach isn't suitable for granular caching strategies
 or personalised content.
 
-Read more about [HTTP Caching](http_caching) in our CWP Performance Guide.
+Read more about [HTTP Caching](02_HTTP_Caching.md) in our CWP Performance Guide.
 
 ## Object Caching with SS_Cache
 
@@ -150,4 +150,4 @@ module as well as the [LivePub module](https://github.com/markguinn/silverstripe
 
 ## Next
 
-Continue to our performance guide on [HTTP Caching](http_caching)
+Continue to our performance guide on [HTTP Caching](02_HTTP_Caching.md)

--- a/docs/en/04_Performance_Guide/02_HTTP_Caching.md
+++ b/docs/en/04_Performance_Guide/02_HTTP_Caching.md
@@ -18,8 +18,8 @@ CWP is equipped with two transparent cache systems: A *Local Cache Layer* in the
 
 All instance responses are analysed and some of them may be cached to increase performance. Their behaviour can be controlled:
 
-* through the response headers configured in your code (see the ["Configuration via headers" chapter](#configuration-via-headers-2))
-* if you opted for the [Premium Managed Service](https://www.cwp.govt.nz/features/optional-extras/), through Incapsula configuration panel (see the ["Configuration via Incapsula" chapter](#configuration-via-incapsula-2))
+* through the response headers configured in your code (see the ["Configuration via headers" chapter](#configuration-via-headers))
+* if you opted for the [Premium Managed Service](https://www.cwp.govt.nz/features/optional-extras/), through Incapsula configuration panel (see the ["Configuration via Incapsula" chapter](#configuration-via-incapsula))
 
 The default recipes are configured conservatively to protect the data. This means SilverStripe Framework responses will not be cached at all. All other resources (static files) will be cached for a short period of time (see below for details).
 
@@ -45,7 +45,7 @@ This test should not be treated as representative for all CWP sites as it depend
 Agencies are urged to carry out their own load testing to determine the exact performance profile of their site.
 
 Also see the *"Can I leverage caching so that I can fit a large site on a small instance?"* question in the 
-[FAQ below](#faq-2).
+[FAQ below](#faq).
 
 ### Cache levels
 
@@ -110,15 +110,13 @@ SilverStripe\Core\Injector\Injector:
       Policies: '%$LightCachingPolicy'
 ```
 
-You might also want to inspect the default _Vary_ used by this module to see if it works well with your content, and perhaps adjust it via `CachingPolicy::vary` configuration option. See the ["Varying content" chapter](#varying-content-2) on the possible permutations of this header.
+You might also want to inspect the default _Vary_ used by this module to see if it works well with your content, and perhaps adjust it via `CachingPolicy::vary` configuration option. See the ["Varying content" chapter](#varying-content) on the possible permutations of this header.
 
 #### Full caching on dynamic content
 
-Full caching can only be achieved on dynamic content if that content is non-varying (see ["Varying content" chapter](#varying-content-2)).
+Full caching can only be achieved on dynamic content if that content is non-varying (see ["Varying content" chapter](#varying-content)).
 
-<div class="alert alert-warning" markdown='1'>
 Be cautious! If you feel uncertain about identifying content as non-varying, better stick to "Light" caching and avoid the danger of leaking user-specific or confidential data altogether.
-</div>
 
 ```
 Injector:
@@ -150,7 +148,7 @@ A table of some more obvious _Vary_ headers can be found in the [Controller Poli
 
 Check your `.htaccess` files in the webroot and any subfolders, as they can influence the `Vary` header. For example, a `%{HTTP_HOST}` rewrite condition will [auto-add](http://httpd.apache.org/docs/current/mod/mod_rewrite.html) a `Vary: Host` header.
 
-If your content truly does not vary depending on the request, you will be able to utilise full caching for that URL - see the ["Full caching on dynamic content" chapter](#full-caching-on-dynamic-content-2).
+If your content truly does not vary depending on the request, you will be able to utilise full caching for that URL - see the ["Full caching on dynamic content" chapter](#full-caching-on-dynamic-content).
 
 Note that CWP's Local Cache (Varnish) has slightly different caching rules from the CDN (Incapsula). Depending on your headers, you might see cache hits from the Local Cache, but not from the CDN.
 
@@ -185,12 +183,10 @@ On CWP the _Static+Dynamic_ mode was not observed to be any different from the _
 
 Incapsula will also attempt to compress JPEG and PNG images as well as minify CSS, but will not minify JS.
 
-<div class="alert alert-info" markdown='1'>
 Important: If you have a access to the Incapsula dashboard through the Premium Managed Service,
 your settings there only influence responses from your own domain(s).
 Content served through "*.cwp.govt.nz" domains will not be affected by your changes.
 This conveniently includes responses generated from the CMS admin area which shouldn't be retained in the cache at all.
-</div>
 
 
 ### Potentially dangerous settings in Incapsula
@@ -202,7 +198,7 @@ You should not change these if any of the following is true:
 - Sections of your publicly-accessible site are protected by HTTP Basic authentication.
 - Your site is protected by an IP whitelist which wasn’t requested through the CWP Service Desk.
 
-See ["Varying content" chapter](#varying-content-2) for more details. If your site is completely public information, or you endeavour to maintain a tightly controlled list of Incapsula exceptions, you can change these __at your own risk__.
+See ["Varying content" chapter](#varying-content) for more details. If your site is completely public information, or you endeavour to maintain a tightly controlled list of Incapsula exceptions, you can change these __at your own risk__.
 
 ## Debugging
 
@@ -271,4 +267,4 @@ Since SSL traffic is terminated before it hits CWP's Local Cache layer, you can 
 
 ## Next
 
-Continue to our performance guide on [Deferring Work](deferring_work)
+Continue to our performance guide on [Deferring Work](03_Deferring_Work.md)

--- a/docs/en/04_Performance_Guide/03_Deferring_Work.md
+++ b/docs/en/04_Performance_Guide/03_Deferring_Work.md
@@ -22,10 +22,8 @@ confirmation to the user once the job has been added, and let the queue run the 
 may mean a small delay on the sending of the email while the job makes its way to the top of the queue, but it provides 
 a much better experience for the user - and reduces the impact on the server.
 
-<div class="alert alert-info">
-    This also helps to mitigate the impact of Denial of Service (DOS) attacks, as it is much harder to induce load when 
-    you remove the processing from the request. The queue ensures sensible distribution of the server resources.
-</div>
+This also helps to mitigate the impact of Denial of Service (DOS) attacks, as it is much harder to induce load when 
+you remove the processing from the request. The queue ensures sensible distribution of the server resources.
 
 You can see this in action with the Solr Reindex Task - where previously this would execute inside the request and 
 potentially throw an error after timing out, now it adds a `SolrReindexJob` to the queue and returns a standard task
@@ -58,4 +56,4 @@ sustain higher amounts of simultaneous users.
 
 ## Next
 
-Continue to our performance guide on [Frontend Best Practices](frontend_best_practices).
+Continue to our performance guide on [Frontend Best Practices](04_Frontend_Best_Practices.md).

--- a/docs/en/04_Performance_Guide/04_Frontend_Best_Practices.md
+++ b/docs/en/04_Performance_Guide/04_Frontend_Best_Practices.md
@@ -15,7 +15,7 @@ will focus on a few that will have the most use on the CWP environments.
 
 Firstly though, it is important to know what is already being done. Incapsula, as well as being a Web Application 
 Firewall, provides CWP sites with a Content Distribution Network (CDN). This means that some requests can be served by
-Incapsula, rather than using server processing power. Read the ["HTTP Caching" chapter](http_caching) for details.
+Incapsula, rather than using server processing power. Read the ["HTTP Caching" chapter](02_HTTP_Caching.md) for details.
 
 One of the other benefits of Incapsula is that it provides content optimisation, which CWP sites will use by default. 
 This includes:
@@ -48,8 +48,8 @@ bottom. With a standard load, you need to wait for any given element to load bef
 load something large (say, a script) asynchronously, we can let the HTML around it load, and then execute once the
 entire script has loaded. This is particularly advantageous in two situations:
 
-* [Large Scripts](#large-scripts-2)
-* [Third-party Content](#third-party-content-2)
+* [Large Scripts](#large-scripts)
+* [Third-party Content](#third-party-content)
 
 ### Large Scripts
 
@@ -75,8 +75,8 @@ bring this content in asynchronously.
 
 [read more...](https://browserdiet.com/#3rd-party-async)
 
-For more information on optimising your third-party integrations, see [our guide](../third-parties).
+For more information on optimising your third-party integrations, see [our guide](05_Third_Parties.md).
 
 ## Next
 
-Continue to our performance guide on [Handling Third Parties](third_parties).
+Continue to our performance guide on [Handling Third Parties](05_Third_Parties.md).

--- a/docs/en/04_Performance_Guide/05_Third_Parties.md
+++ b/docs/en/04_Performance_Guide/05_Third_Parties.md
@@ -21,10 +21,8 @@ worth speaking with the external provider to find out what their expectation is 
 A good rule of thumb is to expect most requests to respond within 5 seconds; but remember, if you set a timeout to 5 
 seconds, then on some page loads you may see loading times increase by this much to accommodate slow responses. 
 
-<div class="alert alert-info">
 Note that if a response from your site to your visitor takes over 30 seconds, a 502 error response will be sent by the
 CWP infrastructure, regardless of other timeout settings.
-</div>
 
 ### Caching response data
 
@@ -51,10 +49,8 @@ Many times the data you'll be fetching from external providers will change infre
 longer without going "stale" (where the data you've cached is out-of-date compared to the live data source). Often there
 will be little harm in showing stale data to your visitors.
 
-<div class="alert alert-info">
 Discuss with your stakeholders what level of stale data is acceptable - it may be different for each piece of data 
 you cache.
-</div>
 
 If the data you're accessing changes frequently, you should adjust your caching rules to account for this.
 
@@ -99,4 +95,4 @@ request "just in time" to ensure you only fetch the data you need.
 
 ## Next
 
-Continue to our performance guide on [404s](404s).
+Continue to our performance guide on [404s](06_404s.md).

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.1.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.1.0.md
@@ -18,7 +18,7 @@ The following new major features are included in this release:
 
 Also included is a new file-tracking system to display which pages each image appears on.
 
-![File List](/_images/recipe_1.1.0_filelist.png)
+![File List](../_images/recipe_1.1.0_filelist.png)
 
 ## Security Release Notes
 

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.1.1.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.1.1.md
@@ -35,12 +35,12 @@ module is present, then that folder will have the secure permissions applied aut
 Any existing user form with a file upload field can be secured in recipe 1.1.0 by ensuring that
 the selected folder of any such field is pointed to a secure folder location.
 
-![Select folder](/_images/recipe_1.1.1_select_folder.png)
+![Select folder](../_images/recipe_1.1.1_select_folder.png)
 
 Then manually confirm that the selected folder is set to an appropriate level of access under the
 "Files" cms section.
 
-![Secure folder](/_images/recipe_1.1.1_secure_folder.png)
+![Secure folder](../_images/recipe_1.1.1_secure_folder.png)
 
 ## New Features and Modules
 
@@ -59,7 +59,7 @@ Once you upgrade, the following features will be *automatically enabled*:
  * Search re-indexing now happens incrementally, and can now be queued. New re-index
    jobs will cancel running ones, leading to faster, and more robust indexing overall.
    You can read more about the performance improvements we have made in the
-   [module documentation](/features/solr_search#performance-implications-and-limitations).
+   [module documentation](../02_Features/solr_search#performance-implications-and-limitations).
  * QueuedJobs module has be greatly improved to be more stable and efficient. When enabled,
    jobs can now be executed in parallel processes. Failing parallel process jobs can no longer block the queue.
 
@@ -67,10 +67,10 @@ The following features will *require some additional work* in addition to the up
 
  * Full-text searching can support synonyms with some configuration by a back-end developer. Once this is
    complete, a content author will need to define appropriate synonyms for your site. Both steps are detailed in the
-   [module documentation](/features/solr_search#search-term-synonyms).
+   [module documentation](../02_Features/solr_search#search-term-synonyms).
  * Full-text search can support boosting with some configuration by a back-end developer. Once this
    is complete, content authors can mark certain pages as top-ranking results for specific pages in
-   the CMS. Both steps are detailed in the [module documentation](/features/solr_search#boosting-results).
+   the CMS. Both steps are detailed in the [module documentation](../02_Features/solr_search#boosting-results).
 
 ## Upgrading Instructions
 

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.2.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.2.0.md
@@ -42,7 +42,7 @@ the contract. This is a last resort as it will incur cost and creates a risk of 
     for use in the database, greatly improving the security of applications by reducing the risk of SQL injection.
   - Reports and Siteconfig have been moved to separate modules.
 
-![3.2 screenshot](/_images/recipe_1.2.0_3.2_framework.png)
+![3.2 screenshot](../_images/recipe_1.2.0_3.2_framework.png)
 
 For more information on how to prepare your existing code for compatibility with 3.2, please review
 [the 3.2 changelog](https://docs.silverstripe.org/en/3.2/changelogs/3.2.0/) for specific upgrading instructions.

--- a/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.3.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_recipe_basic_1.3.0.md
@@ -26,7 +26,7 @@ in the following areas:
   - "Access to Pages section"
   - "View draft content"
 
-![3.3 screenshot](/_images/recipe_1.3.0_3.3_framework.png)
+![3.3 screenshot](../_images/recipe_1.3.0_3.3_framework.png)
 
 For more information on how to prepare your existing code for compatibility with 3.3, please review
 [the 3.3 changelog](https://docs.silverstripe.org/en/3.3/changelogs/3.3.0/) for specific upgrading instructions.


### PR DESCRIPTION
I've update some broken links in the documentation. 
Everything should be consistent and users will be able to click through it on github.