### PR TITLE
FIX Set default_locale to en_NZ, and allow errors to be returned as 200 OK

### DIFF
--- a/_config/spellcheck.yml
+++ b/_config/spellcheck.yml
@@ -7,6 +7,8 @@ SilverStripe\SpellCheck\Handling\SpellCheckMiddleware:
   editor: cwp
 
 SilverStripe\SpellCheck\Handling\SpellController:
+  return_errors_as_ok: true
+  default_locale: en_NZ
   locales:
     - en_NZ
     - mi_NZ


### PR DESCRIPTION
Requires https://github.com/silverstripe/silverstripe-spellcheck/pull/36

Resolves https://github.com/silverstripe/cwp/issues/79