### PR TITLE
Update version label on site summary report for CWP

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -65,3 +65,11 @@ Only:
 CommentingController:
   extensions:
     - CwpCommentingExtension
+---
+Name: cwpsitesummaryextensions
+Only:
+  moduleexists: 'silverstripe-maintenance'
+---
+SiteSummary:
+  extensions:
+    - CwpSiteSummaryExtension

--- a/code/extensions/CwpSiteSummaryExtension.php
+++ b/code/extensions/CwpSiteSummaryExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Extends the site summary report to list the appropriate versions in the report header
+ */
+class CwpSiteSummaryExtension extends Extension
+{
+
+    /**
+     * Updates the modules used for the version label by:
+     *  - Removing SS Framework
+     *  - Adding CWP
+     *  - Relabelling SS CMS
+     *
+     * @param array $modules
+     */
+    public function updateVersionModules(&$modules)
+    {
+        unset($modules['silverstripe/framework']);
+        $modules = ['cwp/cwp' => 'CWP'] + $modules;
+        $modules['silverstripe/cms'] = 'SilverStripe CMS';
+    }
+}


### PR DESCRIPTION
With the new "Site Summary" report being adding in silverstripe-maintenance, this PR updates the version label displayed to show the CWP version instead of the SilverStripe framework version

Related to bringyourownideas/silverstripe-maintenance#35