### PR TITLE
DOCS Update support timelines for CWP 1.8.1 and CWP 1.8.2

### DIFF
--- a/docs/en/05_Releases_and_changelogs/index.md
+++ b/docs/en/05_Releases_and_changelogs/index.md
@@ -6,8 +6,8 @@ introduction: The status of the recipe releases is summarised in the table below
 
 | Recipe version | Description | Release date | Support ends date |
 | -------------- | ----------- | ------------ | ----------------- |
-| [1.8.2](cwp_recipe_basic_1.8.2) | Tracks the Framework release 3.6.6, and includes security fixes. | 28/05/2018 | current |
-| [1.8.1](cwp_recipe_basic_1.8.1) | Tracks the Framework release 3.6.5, and includes minor module bug fixes. | 12/03/2018 | current |
+| [1.8.2](cwp_recipe_basic_1.8.2) | Tracks the Framework release 3.6.6, and includes security fixes. | 28/05/2018 | 30/11/2019 |
+| [1.8.1](cwp_recipe_basic_1.8.1) | Tracks the Framework release 3.6.5, and includes minor module bug fixes. | 12/03/2018 | 30/11/2019 |
 | [1.8.0](cwp_recipe_basic_1.8.0) | Tracks the Framework release 3.6.3 and includes security fixes. | 11/12/2017 | 12/09/2019 |
 | [1.7.0](cwp_recipe_basic_1.7.0) | Tracks the Framework release 3.6.1 and includes security fixes. | 28/09/2017 | 11/06/2019 |
 | [1.6.0](cwp_recipe_basic_1.6.0) | Tracks the Framework release 3.6.0 and includes security fixes. | 02/06/2017 | 28/03/2019 |


### PR DESCRIPTION
This sets the support end date for CWP 1.8.1 and 1.8.2 to 18 months from today.

cc @chillu @sminnee