### PR TITLE
Add statement about testing for server/config issues

### DIFF
--- a/docs/en/02_Features/01_Solr_search/00_Configuration.md
+++ b/docs/en/02_Features/01_Solr_search/00_Configuration.md
@@ -48,3 +48,5 @@ This module sets up:
  * Spelling and Synonyms (including setting synonym groups in SiteConfig)
  * Boosting keywords extension to pages
  * Custom routing to the CWP search controller (see _config/routes.yml)
+
+ If you choose to customise the module's out-of-the-box behaviour with your own custom integration, ensure that your code gracefully handles Solr connectivity or configuration issues, such as server outages or invalid search index definitions.


### PR DESCRIPTION
Solr isn't perfect, we all know that, and developers building custom integrations outside of a standard search form and page should be aware that they need to ensure that their code handles a Solr issue gracefully (such as the server going down, or the index being busted) and their code doesn't cause a full site outage.

Happy to work on the wording if needed.