### PR TITLE
FIX Maintenance module extension now provides CWP proxy information for HTTP requests

### DIFF
--- a/_config/maintenance.yml
+++ b/_config/maintenance.yml
@@ -1,0 +1,13 @@
+---
+Name: maintenanceproxyextensions
+Before: updatecheckerextensions
+Only:
+  moduleexists: bringyourownideas/silverstripe-maintenance
+---
+BringYourOwnIdeas\Maintenance\Util\ComposerLoader:
+  extensions:
+    - CWP\CWP\Extension\MaintenanceProxyExtension
+
+BringYourOwnIdeas\Maintenance\Util\ApiLoader:
+  extensions:
+    - CWP\CWP\Extension\MaintenanceProxyExtension

--- a/_config/maintenance.yml
+++ b/_config/maintenance.yml
@@ -2,12 +2,12 @@
 Name: maintenanceproxyextensions
 Before: updatecheckerextensions
 Only:
-  moduleexists: bringyourownideas/silverstripe-maintenance
+  moduleexists: silverstripe-maintenance
 ---
 BringYourOwnIdeas\Maintenance\Util\ComposerLoader:
   extensions:
     - CWP\CWP\Extension\MaintenanceProxyExtension
 
-BringYourOwnIdeas\Maintenance\Util\ApiLoader:
+BringYourOwnIdeas\Maintenance\Util\SupportedAddonsLoader:
   extensions:
     - CWP\CWP\Extension\MaintenanceProxyExtension

--- a/code/extensions/MaintenanceProxyExtension.php
+++ b/code/extensions/MaintenanceProxyExtension.php
@@ -2,13 +2,7 @@
 
 namespace CWP\CWP\Extension;
 
-use BringYourOwnIdeas\Maintenance\Reports\SiteSummary;
-use SilverStripe\Core\Environment;
-use SilverStripe\Core\Extension;
-
-if (!class_exists(SiteSummary::class)) {
-    return;
-}
+use Extension;
 
 /**
  * Used to configure proxy settings for bringyourownideas/silverstripe-maintenance and its related modules
@@ -25,11 +19,6 @@ class MaintenanceProxyExtension extends Extension
      */
     public function onAfterBuild()
     {
-        // Mock COMPOSER_HOME if it's not defined already. Composer requires one of the two to be set.
-        if (!Environment::getEnv('HOME') && !Environment::getEnv('COMPOSER_HOME')) {
-            putenv('COMPOSER_HOME=/tmp');
-        }
-
         // Provide access for Composer's StreamContextFactory, since it creates its own stream context
         if ($proxy = $this->getCwpProxy()) {
             $_SERVER['CGI_HTTP_PROXY'] = $proxy;
@@ -56,14 +45,14 @@ class MaintenanceProxyExtension extends Extension
      */
     protected function getCwpProxy()
     {
-        if (!Environment::getEnv('SS_OUTBOUND_PROXY') || !Environment::getEnv('SS_OUTBOUND_PROXY_PORT')) {
+        if (!defined('SS_OUTBOUND_PROXY') || !defined('SS_OUTBOUND_PROXY_PORT')) {
             return '';
         }
 
         return sprintf(
             'tcp://%s:%d',
-            Environment::getEnv('SS_OUTBOUND_PROXY'),
-            Environment::getEnv('SS_OUTBOUND_PROXY_PORT')
+            SS_OUTBOUND_PROXY,
+            SS_OUTBOUND_PROXY_PORT
         );
     }
 }

--- a/src/Extensions/MaintenanceProxyExtension.php
+++ b/src/Extensions/MaintenanceProxyExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace CWP\CWP\Extension;
+
+use BringYourOwnIdeas\Maintenance\Reports\SiteSummary;
+use SilverStripe\Core\Environment;
+use SilverStripe\Core\Extension;
+
+if (!class_exists(SiteSummary::class)) {
+    return;
+}
+
+/**
+ * Used to configure proxy settings for bringyourownideas/silverstripe-maintenance and its related modules
+ *
+ * @see https://www.cwp.govt.nz/developer-docs/en/2/how_tos/external_http_requests_with_proxy
+ */
+class MaintenanceProxyExtension extends Extension
+{
+    /**
+     * Configures required environment settings for Composer's use, applies to
+     * {@link \BringYourOwnIdeas\Maintenance\Util\ComposerLoader} and is applied before ComposerLoaderExtension in
+     * bringyourownideas/silverstripe-composer-update-checker to ensure the proxy information is set before Composer
+     * is created
+     */
+    public function onAfterBuild()
+    {
+        // Mock COMPOSER_HOME if it's not defined already. Composer requires one of the two to be set.
+        if (!Environment::getEnv('HOME') && !Environment::getEnv('COMPOSER_HOME')) {
+            putenv('COMPOSER_HOME=/tmp');
+        }
+
+        // Provide access for Composer's StreamContextFactory, since it creates its own stream context
+        if ($proxy = $this->getCwpProxy()) {
+            $_SERVER['CGI_HTTP_PROXY'] = $proxy;
+        }
+    }
+
+    /**
+     * Provide proxy options for {@link \BringYourOwnIdeas\Maintenance\Util\ApiLoader} instances to use in
+     * their Guzzle clients
+     *
+     * @param array $options
+     */
+    public function updateClientOptions(&$options)
+    {
+        if ($proxy = $this->getCwpProxy()) {
+            $options['proxy'] = $proxy;
+        }
+    }
+
+    /**
+     * Returns a formatted CWP proxy string, e.g. `tcp://proxy.cwp.govt.nz:1234`
+     *
+     * @return string
+     */
+    protected function getCwpProxy()
+    {
+        if (!Environment::getEnv('SS_OUTBOUND_PROXY') || !Environment::getEnv('SS_OUTBOUND_PROXY_PORT')) {
+            return '';
+        }
+
+        return sprintf(
+            'tcp://%s:%d',
+            Environment::getEnv('SS_OUTBOUND_PROXY'),
+            Environment::getEnv('SS_OUTBOUND_PROXY_PORT')
+        );
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/silverstripe/cwp/pull/125

Issue: https://github.com/bringyourownideas/silverstripe-maintenance/issues/113

Also removes the COMPOSER_HOME env var definition, which is now in https://github.com/bringyourownideas/silverstripe-composer-update-checker/pull/35