### PR TITLE
FIX Remove COMPOSER_HOME definition, update-checker module now does this itself

### DIFF
--- a/src/Extensions/MaintenanceProxyExtension.php
+++ b/src/Extensions/MaintenanceProxyExtension.php
@@ -6,10 +6,6 @@ use BringYourOwnIdeas\Maintenance\Reports\SiteSummary;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Extension;
 
-if (!class_exists(SiteSummary::class)) {
-    return;
-}
-
 /**
  * Used to configure proxy settings for bringyourownideas/silverstripe-maintenance and its related modules
  *
@@ -25,11 +21,6 @@ class MaintenanceProxyExtension extends Extension
      */
     public function onAfterBuild()
     {
-        // Mock COMPOSER_HOME if it's not defined already. Composer requires one of the two to be set.
-        if (!Environment::getEnv('HOME') && !Environment::getEnv('COMPOSER_HOME')) {
-            putenv('COMPOSER_HOME=/tmp');
-        }
-
         // Provide access for Composer's StreamContextFactory, since it creates its own stream context
         if ($proxy = $this->getCwpProxy()) {
             $_SERVER['CGI_HTTP_PROXY'] = $proxy;


### PR DESCRIPTION
The change in https://github.com/bringyourownideas/silverstripe-composer-update-checker/pull/35 will be merged up to the SilverStripe 4 branch, which will mean this isn't required any more.

See: https://github.com/bringyourownideas/silverstripe-maintenance/issues/113

Matching CWP 1.x change: https://github.com/silverstripe/cwp/pull/127