### PR TITLE
Ensure NewsPage publishes related image

### DIFF
--- a/src/PageTypes/NewsPage.php
+++ b/src/PageTypes/NewsPage.php
@@ -29,6 +29,10 @@ class NewsPage extends DatedUpdatePage
         'FeaturedImage' => Image::class,
     ];
 
+    private static $owns = [
+        'FeaturedImage',
+    ];
+
     private static $table_name = 'NewsPage';
 
     public function fieldLabels($includerelations = true)


### PR DESCRIPTION
Currently NewsPages require the FeaturedImage to be published separately to appear for site users