### PR TITLE
DOCS Clearer references to main module docs

### DIFF
--- a/docs/en/02_Features/01_Solr_search/03_Basic_usage.md
+++ b/docs/en/02_Features/01_Solr_search/03_Basic_usage.md
@@ -7,7 +7,8 @@ The following as already been pre-configured in the cwp-core and cwp modules tha
 If you used the cwp-installer, or have included the basic recipe in your code you won't need to implement the steps below in your project.
 Rather, these steps give you a high level idea of what is going on "under the hood" of Solr working with SilverStripe CMS.
 
-For additional insight you should take a look at [the official fulltext search documentation](https://github.com/silverstripe/silverstripe-fulltextsearch/blob/master/docs/en/03_configuration.md)
+This document aims to describe the CWP-specific configuration.
+More options are described in the main [fulltextsearch module documentation](https://github.com/silverstripe/silverstripe-fulltextsearch/blob/master/docs/en/index.md).
 
 1) Define an index, and which fields should be searchable.
 
@@ -58,7 +59,7 @@ $results = singleton(MyIndex::class)->search($query);
 
 ### Querying
 
-To find out more about querying and how to write more complex queries, visit the [official fulltext search documentation](https://github.com/silverstripe/silverstripe-fulltextsearch/blob/master/docs/en/04_querying.md). 
+To find out more about querying and how to write more complex queries, visit the main [fulltextsearch module documentation](https://github.com/silverstripe/silverstripe-fulltextsearch/blob/master/docs/en/04_querying.md). 
 
 ### Indexing Multiple Classes
 

--- a/docs/en/02_Features/01_Solr_search/04_Default_search_index.md
+++ b/docs/en/02_Features/01_Solr_search/04_Default_search_index.md
@@ -6,6 +6,9 @@ summary: Information about how the Solr search index is pre-configured for CWP.
 By default, a standard search index `CWP\Search\Solr\CwpSolrIndex` is included in the CWP search recipe.
 This includes basic configuration necessary for searching pages.
 
+This document aims to describe the CWP-specific configuration.
+More options on how to configure indexes are described in main [fulltextsearch module documentation](https://github.com/silverstripe/silverstripe-fulltextsearch/blob/master/docs/en/index.md).
+
 ```php
 namespace CWP\Search\Solr;
 

--- a/docs/en/02_Features/01_Solr_search/06_Tuning_the_search_results.md
+++ b/docs/en/02_Features/01_Solr_search/06_Tuning_the_search_results.md
@@ -3,6 +3,14 @@ summary: How to configure spelling suggestions, synonyms and keyword boosting to
 
 # Fine tuning the search results
 
+## Overview
+
+Search behaviour often needs to adapt to the indexed content.
+The CWP search allows some fine tuning, for example
+by adding spelling suggestions and synonyms.
+
+More ways to adjust search behaviour are described in the main [fulltextsearch module documentation](https://github.com/silverstripe/silverstripe-fulltextsearch/blob/master/docs/en/index.md).
+
 ## Before we begin
 
 **This feature requires cwp recipe 1.1.1 or above including the [cwp](https://github.com/silverstripe/cwp), [cwp-core](https://github.com/silverstripe/cwp-core), [cwp/cwp-search](https://github.com/silverstripe/cwp-search) (for CWP 2.0 or higher) and [fulltextsearch](https://github.com/silverstripe/silverstripe-fulltextsearch) modules specifically.**

--- a/docs/en/02_Features/01_Solr_search/index.md
+++ b/docs/en/02_Features/01_Solr_search/index.md
@@ -6,8 +6,12 @@ summary: Setting up and customising search functionality.
 ## Overview
 
 CWP provides a hosted Solr service to index and search the content of your site. To ensure stability of your stack
-this service lives outside of your environments. The recipe pulls in the [*silverstripe/fulltextsearch*](https://github.com/silverstripe/silverstripe-fulltextsearch) module and
+this service lives outside of your environments. 
+
+The recipe pulls in the [*silverstripe/fulltextsearch*](https://github.com/silverstripe/silverstripe-fulltextsearch) module and
 provides configuration to make sure it works out of the box.
+Please refer to the main
+[fullltextsearch module documentation](https://github.com/silverstripe/cwp/blob/master/docs/en/index.md)
 
 ## Working with Solr
 


### PR DESCRIPTION
- Call the module docs "main docs" rather than "official docs".
  At the moment, it makes it sound like the CWP docs are not official.
- Link to the correct branch on docs
- Link to index instead of section on Github docs,
  since there's no obvious way to navigate back to the index there

Relates to https://github.com/silverstripe/cwp/issues/126
Follow up of https://github.com/silverstripe/cwp/pull/134