### PR TITLE
FIX Text collector translations now compile without errors

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -8,8 +8,12 @@ en:
     TwitterField: 'Twitter username'
     TwitterFieldDesc: 'Twitter username (eg, http://twitter.com/<strong>username</strong>)'
   CWP\CWP\Extensions\CwpCommentingExtension:
+    EMAIL_TITLE: Email
     WEBSITE_TITLE: 'Your website (optional)'
     WILL_NOT_BE_PUBLISHED: 'Will not be published.'
+  CWP\CWP\Extensions\CwpSiteSummaryExtension:
+    FilterSupported: 'CWP recipe modules'
+    FilterUnsupported: 'Non CWP modules'
   CWP\CWP\Extensions\CwpSiteTreeExtension:
     SHOW_PAGE_UTILITIES: 'Show page utilities?'
     SHOW_PAGE_UTILITIES_HELP: 'You can disable page utilities (print, share, etc) for this page'

--- a/src/Extensions/CwpCommentingExtension.php
+++ b/src/Extensions/CwpCommentingExtension.php
@@ -10,6 +10,7 @@ use SilverStripe\Forms\Form;
  * Customises the comment form to conform to government usability standards
  *
  * {@see CommentingController}
+ * @skipUpgrade
  */
 class CwpCommentingExtension extends Extension
 {
@@ -17,9 +18,9 @@ class CwpCommentingExtension extends Extension
     {
         $fields = $form->Fields();
 
-        if ($emailField = $fields->dataFieldByName(Email::class)) {
+        if ($emailField = $fields->dataFieldByName('Email')) {
             $emailField
-                ->setTitle(_t(__CLASS__ . '.EMAIL_TITLE', Email::class))
+                ->setTitle(_t(__CLASS__ . '.EMAIL_TITLE', 'Email'))
                 ->setDescription(_t(__CLASS__ . '.WILL_NOT_BE_PUBLISHED', 'Will not be published.'));
         }
 


### PR DESCRIPTION
Also fixes a bad upgrader changes in regards to Email data field name

Issue: https://github.com/silverstripe/silverstripe-framework/issues/8356