### PR TITLE
API Deprecate BasePage::RelatedPages(), use BasePage::RelatedPagesThrough() instead

### DIFF
--- a/src/Model/RelatedPageLink.php
+++ b/src/Model/RelatedPageLink.php
@@ -4,7 +4,6 @@ namespace CWP\CWP\Model;
 
 use CWP\CWP\PageTypes\BasePage;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\FieldType\DBInt;
 use SilverStripe\Versioned\Versioned;
 
 class RelatedPageLink extends DataObject
@@ -12,11 +11,11 @@ class RelatedPageLink extends DataObject
     private static $table_name = 'BasePage_RelatedPages';
 
     private static $extensions = [
-        Versioned::class
+        Versioned::class,
     ];
 
     private static $db = [
-        'SortOrder' => DBInt::class
+        'SortOrder' => 'Int',
     ];
 
     /**

--- a/src/PageTypes/BasePage.php
+++ b/src/PageTypes/BasePage.php
@@ -2,6 +2,7 @@
 
 namespace CWP\CWP\PageTypes;
 
+use CWP\CWP\Model\RelatedPageLink;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
@@ -14,11 +15,9 @@ use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\TreeMultiselectField;
 use SilverStripe\Taxonomy\TaxonomyTerm;
 use SilverStripe\View\ArrayData;
+use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
-use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
-use SilverStripe\ORM\FieldType\DBInt;
-use CWP\CWP\Model\RelatedPageLink;
 
 /**
  * `BasePage` is a foundation page class which can be used for constructing your own page types. By default it is
@@ -62,7 +61,6 @@ class BasePage extends SiteTree
 
     private static $many_many = [
         'Terms' => TaxonomyTerm::class,
-        'RelatedPages' => BasePage::class,
         'RelatedPagesThrough' => [
             'through' => RelatedPageLink::class,
             'from' => 'BasePage',
@@ -80,7 +78,7 @@ class BasePage extends SiteTree
      */
     private static $many_many_extraFields = [
         'RelatedPages' => [
-            'SortOrder' => DBInt::class,
+            'SortOrder' => 'Int',
         ],
     ];
 
@@ -94,9 +92,12 @@ class BasePage extends SiteTree
         return FooterHolder::get_one(FooterHolder::class);
     }
 
+    /**
+     * @deprecated 2.2.0:3.0.0 Please use RelatedPagesThrough() instead
+     */
     public function RelatedPages()
     {
-        return $this->getManyManyComponents('RelatedPages')->sort('SortOrder');
+        return $this->getManyManyComponents('RelatedPagesThrough');
     }
 
     public function RelatedPagesTitle()


### PR DESCRIPTION
The RelatedPages ORM relationship isn't used in any of the default CWP code any more, and it's causing https://github.com/silverstripe/cwp/issues/156 to break on dev/build. I've removed it and switched the concrete `RelatedPages()` method to return `RelatedPagesThrough()` which is the active ORM relationship for this now.

I've deprecated the previous method from 2.2 onwards.

Resolves https://github.com/silverstripe/cwp/issues/156