### PR TITLE
FIX Add configuration to allow CWP to wait a few seconds before marking queued export generation jobs as complete

### DIFF
--- a/_config/export.yml
+++ b/_config/export.yml
@@ -1,0 +1,7 @@
+---
+Name: cwpqueuedexportconfig
+---
+SilverStripe\GridfieldQueuedExport\Jobs\GenerateCSVJob:
+  # Wait 15 seconds before marking gridfieldqueuedexport jobs as complete to prevent asset synchronisation
+  # timing issues
+  sync_sleep_seconds: 15


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-gridfieldqueuedexport/issues/32