### PR TITLE
Fix missing right click image edit options

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -96,7 +96,7 @@ $cwpEditor
         'sslinkexternal' => $adminModule->getResource('client/dist/js/TinyMCE_sslink-external.js'),
         'sslinkemail' => $adminModule->getResource('client/dist/js/TinyMCE_sslink-email.js'),
     ])
-    ->setOption('contextmenu', 'sslink inserttable | cell row column deletetable');
+    ->setOption('contextmenu', 'sslink ssmedia ssembed inserttable | cell row column deletetable');
 
 $cwpEditor->enablePlugins('template');
 $cwpEditor->enablePlugins('visualchars');


### PR DESCRIPTION
Aligns the format to what `silverstripe-admin` provides.