### PR TITLE
Add legacy yaml file for use with SS3 to SS4 upgrades

### DIFF
--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -1,0 +1,13 @@
+SilverStripe\ORM\DatabaseAdmin:
+  classname_value_remapping:
+    Quicklink: CWP\CWP\Model\Quicklink
+    EventPage: CWP\CWP\PageTypes\EventPage
+    DatedUpdatePage: CWP\CWP\PageTypes\DatedUpdatePage
+    NewsHolder: CWP\CWP\PageTypes\NewsHolder
+    SitemapPage: CWP\CWP\PageTypes\SitemapPage
+    BasePage: CWP\CWP\PageTypes\BasePage
+    EventHolder: CWP\CWP\PageTypes\EventHolder
+    FooterHolder: CWP\CWP\PageTypes\FooterHolder
+    DatedUpdateHolder: CWP\CWP\PageTypes\DatedUpdateHolder
+    BaseHomePage: CWP\CWP\PageTypes\BaseHomePage
+    NewsPage: CWP\CWP\PageTypes\NewsPage


### PR DESCRIPTION
I've been working on a SS3 to SS4 upgrade and the page types included in the silverstripe/cwp module don't get updated in the database, when doing a dev/build,  to include the namespace. It would be useful if this legacy.yml file was included in the module.

This has been created by taking the mappings of the .upgrade.yml file already in the module, excluding any of the mappings classes that don't extend DataObject, and placing these into a new legacy.yml file.

Also, I was a little unsure which branch this pull request needed to be raised against, but thought 2.2 seemed likely.