### PR TITLE
DOCS Correct search yaml definition

### DIFF
--- a/docs/en/02_Features/01_Solr_search/05_Searching_dataobjects.md
+++ b/docs/en/02_Features/01_Solr_search/05_Searching_dataobjects.md
@@ -81,7 +81,7 @@ Now in your `mysite/_config/search.yml` file (for example), add the following:
 ```yaml
 ---
 Name: mysearchconfig
-After: #cwpsearch
+After: '#cwpsearch'
 ---
 SilverStripe\Core\Injector\Injector:
   CWP\Search\CwpSearchEngine.search_index:

--- a/docs/en/02_Features/01_Solr_search/07_Searching_documents.md
+++ b/docs/en/02_Features/01_Solr_search/07_Searching_documents.md
@@ -33,7 +33,7 @@ In mysite/\_config/search.yml:
 ```yaml
 ---
 Name: mysearchconfig
-After: #cwpsearch
+After: '#cwpsearch'
 ---
 SilverStripe\Core\Injector\Injector:
   CWP\Search\CwpSearchEngine.search_index:


### PR DESCRIPTION
Unquoted config fragments in before/after just get ignored.