### PR TITLE
DOCS add post-2020 note to changlog index

### DIFF
--- a/docs/en/05_Releases_and_changelogs/index.md
+++ b/docs/en/05_Releases_and_changelogs/index.md
@@ -2,6 +2,8 @@ title: Releases and changelogs
 summary: Upgrading guides, changelogs and support timeframes for each released version of the CWP recipe codebase.
 introduction: The status of the recipe releases is summarised in the table below. Upgrading information for each version is available in the changelog.
 
+Support will continue beyond 16 September 2020 when the Lead Agency Agreement ends. [Read more](https://www.cwp.govt.nz/plans/service-continuation/).
+
 # Releases and changelogs
 
 | Recipe version | Description | Release date | Support ends date |


### PR DESCRIPTION
The CWP Lead Agency agreement ends in September 2020. As some CWP versions will be supported for longer than the Lead Agency Agreement, we're adding a note to a 'service continuation' page on cwp.govt.nz to provide further information.

This will also need to be merged up to master to be reflected on cwp.govt.nz.

I'm not entirely sure on whether this sentence needs to be on the same line as the `introduction:` tag though...