### PR TITLE
FIX re-enable TinyMCE anchor plugin

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -92,11 +92,12 @@ $cwpEditor
     ->enablePlugins([
         'contextmenu' => null,
         'image' => null,
+        'anchor' => null,
         'sslink' => $adminModule->getResource('client/dist/js/TinyMCE_sslink.js'),
         'sslinkexternal' => $adminModule->getResource('client/dist/js/TinyMCE_sslink-external.js'),
         'sslinkemail' => $adminModule->getResource('client/dist/js/TinyMCE_sslink-email.js'),
     ])
-    ->setOption('contextmenu', 'sslink ssmedia ssembed inserttable | cell row column deletetable');
+    ->setOption('contextmenu', 'sslink anchor ssmedia ssembed inserttable | cell row column deletetable');
 
 $cwpEditor->enablePlugins('template');
 $cwpEditor->enablePlugins('visualchars');


### PR DESCRIPTION
The default profile in Silverstripe CMS 4 does not have the anchor
plugin enabled. It also seems that the copy-pasted config is not
actually 'inheriting' the default editor settings (as is the nature
of a re-definition), and thus the CWP editor config did not have the
anchor plugin enabled.

Perhaps the CWP config could be made to 'inherit' from the default
CMS config, via getOptions and setOptions, but this should be a
separate issue.

Resolves #244