### PR TITLE
Revert "API Remove mimevalidator from explicit CWP requirements"

### DIFF
--- a/_config/mimevalidator.yml
+++ b/_config/mimevalidator.yml
@@ -1,0 +1,8 @@
+---
+Name: mimeuploadvalidator
+Only:
+  moduleexists: 'silverstripe/mimevalidator'
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Assets\Upload_Validator:
+    class: SilverStripe\MimeValidator\MimeUploadValidator


### PR DESCRIPTION
Reverts silverstripe/cwp#268

Tried upgrading a CWP 2.5 site to 2.x. Originally, I got confused and assumed the `mimevalidator.yml` file was getting copied in the main project like a recipe. But `cwp/cwp` is not a recipe, so `mimevalidator.yml` should stay where it is.

When CWP project upgrade they will get another `mimevalidator.yml` file in their `app/_config` YML that duplicate the `cwp/cwp` one.

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/8782