### PR TITLE
Document removal of Subsites in 2.6.0

### DIFF
--- a/docs/en/01_Working_with_projects/03_Recipes_and_supported_modules.md
+++ b/docs/en/01_Working_with_projects/03_Recipes_and_supported_modules.md
@@ -16,10 +16,11 @@ The [Common Web Platform Installer](https://github.com/silverstripe/cwp-installe
 [CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms), 
 the [CWP Search Recipe](https://github.com/silverstripe/cwp-recipe-search), 
 the [Registry module](https://github.com/silverstripe/silverstripe-registry), 
-the [Fluent module](https://github.com/tractorcow/silverstripe-fluent), and
-the [Subsites module](https://github.com/silverstripe/silverstripe-subsites).
+the [Fluent module](https://github.com/tractorcow/silverstripe-fluent).
 
-These 'metapackages' will be from now on referred to as "recipes", and are crucial elements of keeping your CWP 
+Versions prior to 2.6.0 also included the [Subsites module](https://github.com/silverstripe/silverstripe-subsites).
+
+These 'metapackages' will be from now on referred to as "recipes", and are crucial elements of keeping your CWP
 deployment running.
 
 ## CWP recipe options
@@ -105,7 +106,7 @@ Adds extra CMS reporting tools to your SilverStripe project. It includes the fol
 * [External Links](https://github.com/silverstripe/silverstripe-externallinks) - The module tracks external broken links in SilverStripe CMS pages
 * [Reports](https://github.com/silverstripe/silverstripe-reports) The module contains the API for creating backend reports in the SilverStripe Framework
 * [Security Report](https://github.com/silverstripe/silverstripe-securityreport) - The module adds a "Users, Groups and Permissions" report in the SilverStripe CMS
-* [Site-wide Content Report](https://github.com/silverstripe/silverstripe-sitewidecontent-report) - The module adds a report of all pages and files across all the project, including subsites
+* [Site-wide Content Report](https://github.com/silverstripe/silverstripe-sitewidecontent-report) - The module adds a report of all pages and files across all the project, including subsites (if installed)
 * [SilverStripe Maintenance](https://github.com/bringyourownideas/silverstripe-maintenance) - The module reduces your maintenance related work.
 * [SilverStripe Security Checker](https://github.com/bringyourownideas/silverstripe-composer-security-checker) - The module adds a task which runs a check if any of the dependencies has known security vulnerabilities.
 * [SilverStripe Composer Update Checker](https://github.com/bringyourownideas/silverstripe-composer-update-checker) - The module checks if any of your Composer dependencies needs to be updated, and tracks the available and latest versions that can be updated to.

--- a/docs/en/02_Features/content_review.md
+++ b/docs/en/02_Features/content_review.md
@@ -6,7 +6,7 @@ summary: Set up content review times and send reminder emails to ensure content 
 Content review in the CWP basic recipe is implemented using:
 
  * [silverstripe/contentreview](https://github.com/silverstripe/silverstripe-contentreview) - provides the main functionality for the feature.
- * [silverstripe/sitewidecontent-report](https://github.com/silverstripe/silverstripe-sitewidecontent-report) - provides an extension and report to show the review status of all content (including across subsites).
+ * [silverstripe/sitewidecontent-report](https://github.com/silverstripe/silverstripe-sitewidecontent-report) - provides an extension and report to show the review status of all content (including across subsites, if installed).
  * [silverstripe/queuedjobs](https://github.com/symbiote/silverstripe-queuedjobs) - handles sending of reminder emails for content review at regular intervals.
  
 Both modules are pre-configured to apply a series of `DataExtension` classes so no additional configuration is required to enable once installed.

--- a/docs/en/02_Features/multiple_sites.md
+++ b/docs/en/02_Features/multiple_sites.md
@@ -9,7 +9,11 @@ For more information about the subsites module go to the [github repository](htt
 
 # Setup
 
-The subsites module is already included as part of the CWP basic recipe. To set up a subsite in the CMS visit the [user documentation](https://userhelp.silverstripe.org/en/optional_features/working_with_multiple_sites/set_up).
+This module was provided by default in the CWP basic recipe in versions prior to 2.6.0. From this version onwards, you need to install it manually:
+
+`composer require silverstripe/subsites ^2.3`
+
+To learn how to set up a subsite in the CMS, visit the [user documentation](https://userhelp.silverstripe.org/en/optional_features/working_with_multiple_sites/set_up).
 
 # Technical
 

--- a/docs/en/05_Releases_and_changelogs/cwp_2.6.0.md
+++ b/docs/en/05_Releases_and_changelogs/cwp_2.6.0.md
@@ -26,6 +26,22 @@ This CWP release includes an update to the [fulltextsearch module](https://githu
 
 If your website requires draft content to be indexed, you can [opt-out](https://github.com/silverstripe/silverstripe-fulltextsearch/blob/3/README.md#important-note-when-upgrading-to-fulltextsearch-37) of the new secure defaults.
 
+### Subsites is no longer included in the default CWP installation
+
+The [Subsites module](https://github.com/silverstripe/silverstripe-subsites) has been removed from
+[cwp/installer](https://github.com/silverstripe/cwp-installer) in 2.6.0, in order to reduce the
+default technical footprint of the recipe. Many sites operate without need of Subsites, and we feel
+that including this module should be left as an explicit decision for developers to make.
+
+New projects that need Subsites will need to manually install it via Composer:
+
+```
+composer require silverstripe/subsites ^2.3
+```
+
+We will also no longer reference it in the Upgrading instructions section. If your site depends on
+Subsites, ensure you continue to include and update the module in your Composer requirements.
+
 ## Upgrading instructions
 
 In order to update an existing site to use the new CWP recipe the following changes to your composer.json can be made:
@@ -43,7 +59,6 @@ In order to update an existing site to use the new CWP recipe the following chan
     "silverstripe/recipe-services": "1.6.0@stable",
 
     TODO: confirm new version (below are the old versions, which may still be correct)
-    "silverstripe/subsites": "2.3.3@stable",
     "tractorcow/silverstripe-fluent": "4.4.5@stable",
     "silverstripe/registry": "2.2.1@stable",
     "cwp/starter-theme": "3.0.3@stable"

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -42,15 +42,15 @@ developed code alongside:
  * The [Common Web Platform Installer](https://github.com/silverstripe/cwp-installer) includes all of the above.
  * The [CWP Agency Extensions Module](https://github.com/silverstripe/cwp-agencyextensions) can be added to any of the 
  above.
- 
-  A base for jump-starting development of a CWP project is the 
-  [Common Web Platform Installer](https://github.com/silverstripe/cwp-installer) package. This is a recommended way of 
-  creating a CWP project. 
-  The package includes the [CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms), the 
-  [CWP Search Recipe](https://github.com/silverstripe/cwp-recipe-search), the 
-  [Registry module](https://github.com/silverstripe/silverstripe-registry), the 
-  [Fluent module](https://github.com/tractorcow/silverstripe-fluent), and the 
-  [Subsites module](https://github.com/silverstripe/silverstripe-subsites).
+
+A base for jump-starting development of a CWP project is the
+[Common Web Platform Installer](https://github.com/silverstripe/cwp-installer) package. This is a recommended way of
+creating a CWP project.
+The package includes the [CWP CMS Recipe](https://github.com/silverstripe/cwp-recipe-cms), the
+[CWP Search Recipe](https://github.com/silverstripe/cwp-recipe-search), the
+[Registry module](https://github.com/silverstripe/silverstripe-registry), and the
+[Fluent module](https://github.com/tractorcow/silverstripe-fluent).
+In versions prior to 2.6.0, the package also included the [Subsites module](https://github.com/silverstripe/silverstripe-subsites).
 
 For general information about working with SilverStripe CMS code, please consult the
 [Official SilverStripe CMS developer documentation](https://docs.silverstripe.org/). 


### PR DESCRIPTION
The Subsites module is no longer included in the `cwp/installer` recipe as of 2.6.0. This PR adds a note about this change to the 2.6.0 changelog, and adjusts references to the Subsites module in the CWP developer documentation.

Resolves #272.