### PR TITLE
Clarify DocumentRoot configuration within CWP and its implications

### DIFF
--- a/docs/en/03_How_tos/redirections.md
+++ b/docs/en/03_How_tos/redirections.md
@@ -36,10 +36,17 @@ Once you have that then the redirection should be as follows:
 RewriteCond %{HTTP_HOST} ^my\.domain\.govt\.nz$
 RewriteCond %{HTTPS} !=on
 Rewritecond %{HTTP:X-Forwarded-Proto} !https [NC]
-RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+RewriteCond %{REQUEST_URI} ^/(?:public/)?(.*)$ [NC]
+RewriteRule ^(.*)$ https://%{HTTP_HOST}/%1 [L,R=301]
 ```
 
 This will then force all traffic to redirect to HTTPS on `my.domain.govt.nz`.
+
+To support both Silverstripe CMS 3.x and Silverstripe CMS 4.x versions (with and without the `/public` folder), DocumentRoot for CWP instance's virtual host points to the root folder (the code repository), regardless of the presence of the `/public` folder.
+
+Root level `.htaccess` is used to redirect all content to the `/public` folder when it's present for Silverstripe CMS 4.x sites.
+
+This needs to be taken into account when using `%{REQUEST_URI}` in your rewrite rules, or using `RewriteMatch` directive — both variables are DocumentRoot based.
 
 ## \_config.php
 


### PR DESCRIPTION
As per the title.

We had several iterations on the "why don't redirects work as expected" topic and a lot of back and forth communication with CWP service desk to finally untangle the mystery of how things are configured and what the implications of that are.

This PR updates the documentation to reflect that so that no more developers need to go through the same pain. I'd hope that this would be a basic knowledge of the support staff and participating agencies and vendors won't have to do this troubleshooting for CWP anymore.