### PR TITLE
DEP Update dependency for silverstripe/framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.3 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.13",
         "cwp/cwp-core": "^2",
         "silverstripe/cms": "^4",
         "silverstripe/taxonomy": "^2",


### PR DESCRIPTION
This needs to be bumped because we're calling `Deprecation::withNoReplacement()` which isn't available until 4.13.0

## Issue
- https://github.com/silverstripe/cwp/issues/327