### PR TITLE
FIX Update TinyMCE config for v6 compatibility

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -20,7 +20,6 @@ $cwpEditor->setOptions([
     'friendly_name' => 'Default CWP',
     'priority' => '60',
     'skin' => 'silverstripe',
-    'mode' => 'none',
     'body_class' => 'typography',
     'document_base_url' => Director::absoluteBaseURL(),
     'cleanup_callback' => "sapphiremce_cleanup",
@@ -90,7 +89,6 @@ if ($assetAdminModule) {
 $adminModule = ModuleLoader::inst()->getManifest()->getModule('silverstripe/admin');
 $cwpEditor
     ->enablePlugins([
-        'contextmenu' => null,
         'image' => null,
         'anchor' => null,
         'sslink' => $adminModule->getResource('client/dist/js/TinyMCE_sslink.js'),


### PR DESCRIPTION
This should have been done with the tinymce upgrade. `contextmenu` is no longer its own plugin, it's part of core (see [upgrade notes](https://www.tiny.cloud/docs/migration-from-4x/#changedplugins)).
`mode` is a deprecated option in 5 which was removed in 6: https://www.tiny.cloud/docs/tinymce/6/migration-from-5x/#previously-deprecated-items-now-removed

Leaving these in results in a "Failed to load plugin" console error, and a deprecation warning about the "mode" option. This PR resolves those.

## Issue
- https://github.com/silverstripe/cwp/issues/330