### PR TITLE
FIX Set RelatedPages gridfield to be structural

### DIFF
--- a/src/PageTypes/BasePage.php
+++ b/src/PageTypes/BasePage.php
@@ -17,6 +17,7 @@ use SilverStripe\View\ArrayData;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
+use SilverStripe\Forms\FormField;
 
 /**
  * `BasePage` is a foundation page class which can be used for constructing your own page types. By default it is
@@ -127,15 +128,22 @@ class BasePage extends SiteTree
                 'Root.RelatedPages',
                 _t(__CLASS__ . '.RelatedPages', 'Related pages')
             );
-            $fields->addFieldToTab(
-                'Root.RelatedPages',
-                GridField::create(
-                    'RelatedPages',
-                    _t(__CLASS__ . '.RelatedPages', 'Related pages'),
-                    $this->RelatedPagesThrough(),
-                    $components
-                )
-            );
+            $args = [
+                'RelatedPages',
+                _t(__CLASS__ . '.RelatedPages', 'Related pages'),
+                $this->RelatedPagesThrough(),
+                $components
+            ];
+            $gridField = GridField::create(...$args);
+            // If GridField has been replaced by Injector, use that
+            // Otherwise use anonymous class so that versioned-admin behat tests pass
+            // when running in kitchen-sink
+            if (get_class($gridField) === GridField::class) {
+                $gridField = new class (...$args) extends GridField {
+                    protected $schemaDataType = FormField::SCHEMA_DATA_TYPE_STRUCTURAL;
+                };
+            }
+            $fields->addFieldToTab('Root.RelatedPages', $gridField);
 
             // Taxonomies - Unless they have their own 'Tags' field (such as in Blog, etc)
             $hasMany = $this->hasMany();


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/272

Fixes versioned-admin behat when running in kitchen-sink
- vendor/silverstripe/versioned-admin/tests/Behat/features/revert-to-a-version.feature:25
- vendor/silverstripe/versioned-admin/tests/Behat/features/view-a-version.feature:19
- vendor/silverstripe/versioned-admin/tests/Behat/features/view-a-version.feature:24

Replicatable locally by try to view an individual entry in page history of a page that extends the cwp BasePage